### PR TITLE
[WIP] M78: Support modules/skparagraph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,6 @@ project (skia-bindings)
 
 include_directories(skia-bindings/skia)
 
+add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE)
+
 add_library(skiabindings skia-bindings/src/bindings.cpp skia-bindings/src/shaper.cpp)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?branchName=master)
 
-Skia Submodule Status: chrome/m77 ([pending changes][skiapending]).
+Skia Submodule Status: chrome/m78 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/2417cee95d...chrome/m77
+[skiapending]: https://github.com/google/skia/compare/6d1c0d4196...chrome/m78
 
 ## Goals
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -27,15 +27,19 @@ jobs:
           toolchain: stable
           features: 'shaper'
           exampleArgs: ''
+        stable-textlayout:
+          toolchain: stable
+          features: 'textlayout'
+          exampleArgs: ''
 
       ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
           toolchain: stable
-          features: 'vulkan,svg,shaper'
+          features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         beta-all-features:
           toolchain: beta
-          features: 'vulkan,svg,shaper'
+          features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: ''
 
   variables:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
+include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
+include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/defaults.rs", "src/icu.rs", "src/lib.rs" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "2417cee95d"
+skia = "6d1c0d4196"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -845,6 +845,11 @@ impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
                 .map(|(_, replacer)| replacer(enum_name, original_variant_name))
         })
     }
+
+    fn item_name(&self, _original_item_name: &str) -> Option<String> {
+        println!("item: {}", _original_item_name);
+        None
+    }
 }
 
 type EnumEntry = (&'static str, fn(&str, &str) -> String);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -846,11 +846,6 @@ impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
                 .map(|(_, replacer)| replacer(enum_name, original_variant_name))
         })
     }
-
-    fn item_name(&self, _original_item_name: &str) -> Option<String> {
-        println!("item: {}", _original_item_name);
-        None
-    }
 }
 
 type EnumEntry = (&'static str, fn(&str, &str) -> String);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -824,7 +824,7 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkShaper_TrivialScriptRunIterator",
     // skparagraph
     "std::vector",
-    "std::basic_string",
+    "std::u16string",
     // Vulkan reexports with the wrong field naming conventions.
     "VkPhysicalDeviceFeatures",
     "VkPhysicalDeviceFeatures2",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -600,6 +600,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
+        .parse_callbacks(Box::new(ParseCallbacks))
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")
@@ -1071,6 +1072,7 @@ mod prerequisites {
 
 use bindgen::EnumVariation;
 pub use definitions::{Definition, Definitions};
+use regex::Regex;
 
 pub(crate) mod definitions {
     use std::collections::HashSet;

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -844,11 +844,6 @@ impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
                 .map(|(_, replacer)| replacer(enum_name, original_variant_name))
         })
     }
-
-    fn item_name(&self, _original_item_name: &str) -> Option<String> {
-        println!("item: {}", _original_item_name);
-        None
-    }
 }
 
 type EnumEntry = (&'static str, fn(&str, &str) -> String);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -601,6 +601,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
         .parse_callbacks(Box::new(ParseCallbacks))
+        .raw_line("#![allow(clippy::all)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1072,7 +1072,6 @@ mod prerequisites {
 
 use bindgen::EnumVariation;
 pub use definitions::{Definition, Definitions};
-use regex::Regex;
 
 pub(crate) mod definitions {
     use std::collections::HashSet;

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -600,6 +600,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
+        .parse_callbacks(Box::new(ParseCallbacks))
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -682,6 +682,9 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         // modules/skshaper/
         .whitelist_type("SkShaper")
         .whitelist_type("RustRunHandler")
+        // modules/skparagraph/
+        .whitelist_type("skia::textlayout::Block")
+        .whitelist_type("skia::textlayout::Placeholder")
         // Vulkan reexports that got swallowed by making them opaque.
         .whitelist_type("VkPhysicalDeviceFeatures")
         .whitelist_type("VkPhysicalDeviceFeatures2")
@@ -861,6 +864,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     // TextStyle.h
     ("TextDecorationStyle", replace::k_xxx),
     ("StyleType", replace::k_xxx),
+    ("PlaceholderAlignment", replace::k_xxx),
     // Vk*
     ("VkChromaLocation", replace::vk),
     ("VkFilter", replace::vk),

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -821,6 +821,8 @@ const OPAQUE_TYPES: &[&str] = &[
     // skparagraph
     "std::vector",
     "std::u16string",
+    // skparagraph (m78), (layout fails on macOS and Linux, not sure why, looks like an obscure alignment problem)
+    "skia::textlayout::FontCollection",
     // Vulkan reexports with the wrong field naming conventions.
     "VkPhysicalDeviceFeatures",
     "VkPhysicalDeviceFeatures2",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -602,6 +602,8 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(improper_ctypes)]")
         .parse_callbacks(Box::new(ParseCallbacks))
         .raw_line("#![allow(clippy::all)]")
+        // GrVkBackendContext contains u128 fields on macOS
+        .raw_line("#![allow(improper_ctypes)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -600,7 +600,6 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
-        .parse_callbacks(Box::new(ParseCallbacks))
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -600,10 +600,6 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
-        .parse_callbacks(Box::new(ParseCallbacks))
-        .raw_line("#![allow(clippy::all)]")
-        // GrVkBackendContext contains u128 fields on macOS
-        .raw_line("#![allow(improper_ctypes)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -308,6 +308,12 @@ impl FinalBuildConfiguration {
                 args.push(("skia_use_expat", no()));
             }
 
+            if build.all_skia_libs {
+                // m78: modules/particles forgets to set SKIA_IMPLEMENTATION=1 and so
+                // expects system vulkan headers.
+                flags.push("-DSKIA_IMPLEMENTATION=1");
+            }
+
             if !flags.is_empty() {
                 let flags: String = {
                     let v: Vec<String> = flags.into_iter().map(quote).collect();

--- a/skia-bindings/skparagraph.patch
+++ b/skia-bindings/skparagraph.patch
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 07bdbc2370..90c346acc9 100644
+index 6a85dd96b..809d4724d 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1179,6 +1179,9 @@ group("modules") {
+@@ -1076,6 +1076,9 @@ group("modules") {
      "modules/particles",
      "modules/skottie",
      "modules/skshaper",
@@ -12,3 +12,15 @@ index 07bdbc2370..90c346acc9 100644
    ]
  }
  
+diff --git a/modules/skparagraph/BUILD.gn b/modules/skparagraph/BUILD.gn
+index 5a85d37c4..a3ab9b884 100644
+--- a/modules/skparagraph/BUILD.gn
++++ b/modules/skparagraph/BUILD.gn
+@@ -18,6 +18,7 @@ if (skia_enable_skparagraph) {
+ 
+   component("skparagraph") {
+     import("skparagraph.gni")
++    complete_static_lib = false
+     public_configs = [ ":public_config" ]
+     public = skparagraph_public
+     if (skia_use_icu && skia_use_harfbuzz) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1,3 +1,4 @@
+#include "bindings.h"
 // codec/
 #include "include/codec/SkEncodedOrigin.h"
 // core/
@@ -121,7 +122,6 @@ template<typename T>
 inline sk_sp<T> sp(T* pt) {
     return sk_sp<T>(pt);
 }
-
 
 //
 // codec/SkEncodedOrigin.h

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -68,6 +68,7 @@
 #include "include/effects/SkDropShadowImageFilter.h"
 #include "include/effects/SkGradientShader.h"
 #include "include/effects/SkHighContrastFilter.h"
+#include "include/effects/SkImageFilters.h"
 #include "include/effects/SkImageSource.h"
 #include "include/effects/SkLayerDrawLooper.h"
 #include "include/effects/SkLightingImageFilter.h"
@@ -2006,7 +2007,7 @@ extern "C" SkStreamAsset* C_SkDynamicMemoryWStream_detachAsStream(SkDynamicMemor
 }
 
 //
-// SkGradientShader
+// effects/SkGradientShader.h
 //
 
 extern "C" SkShader* C_SkGradientShader_MakeLinear(const SkPoint pts[2], const SkColor colors[], const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
@@ -2042,7 +2043,7 @@ extern "C" SkShader* C_SkGradientShader_MakeSweep2(SkScalar cx, SkScalar cy, con
 }
 
 //
-// SkPerlinNoiseShader
+// effects/SkPerlinNoiseShader.h
 //
 
 extern "C" SkShader* C_SkPerlinNoiseShader_MakeFractalNoise(SkScalar baseFrequencyX, SkScalar baseFrequencyY, int numOctaves, SkScalar seed, const SkISize* tileSize) {
@@ -2058,7 +2059,7 @@ extern "C" SkShader* C_SkPerlinNoiseShader_MakeImprovedNoise(SkScalar baseFreque
 }
 
 //
-// effects/SkPath1DPathEffect
+// effects/SkPath1DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar advance, SkScalar phase, SkPath1DPathEffect::Style style) {
@@ -2066,7 +2067,7 @@ extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar 
 }
 
 //
-// effects/SkLine2DPathEffect
+// effects/SkLine2DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatrix* matrix) {
@@ -2074,7 +2075,7 @@ extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatri
 }
 
 //
-// effects/SkPath2DPathEffect
+// effects/SkPath2DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const SkPath* path) {
@@ -2082,7 +2083,7 @@ extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const
 }
 
 //
-// effects/SkAlphaThresholdFilter
+// effects/SkAlphaThresholdFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2092,7 +2093,7 @@ C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScala
 }
 
 //
-// effects/SkArithmeticImageFilter
+// effects/SkArithmeticImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor,
@@ -2104,7 +2105,7 @@ extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, flo
 }
 
 //
-// effects/SkBlurDrawLooper
+// effects/SkBlurDrawLooper.h
 //
 
 extern "C" SkDrawLooper* C_SkBlurDrawLooper_Make(SkColor color, SkScalar sigma, SkScalar dx, SkScalar dy) {
@@ -2117,7 +2118,7 @@ extern "C" SkDrawLooper* C_SkBlurDrawLooper_Make2(SkColor4f color, const SkColor
 }
 
 //
-// effects/SkBlurImageFilter
+// effects/SkBlurImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sigmaY, SkImageFilter *input,
@@ -2127,7 +2128,7 @@ extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sig
 }
 
 //
-// effects/SkColorFilterImageFilter
+// effects/SkColorFilterImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkColorFilterImageFilter_Make(SkColorFilter *cf, SkImageFilter *input,
@@ -2160,7 +2161,7 @@ extern "C" SkColorFilter *C_SkColorMatrixFilter_MakeLightingFilter(SkColor mul, 
 }
 
 //
-// effects/SkComposeImageFilter
+// effects/SkComposeImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkComposeImageFilter_Make(SkImageFilter *outer, SkImageFilter *inner) {
@@ -2168,7 +2169,7 @@ extern "C" SkImageFilter *C_SkComposeImageFilter_Make(SkImageFilter *outer, SkIm
 }
 
 //
-// effects/SkCornerPathEffect
+// effects/SkCornerPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
@@ -2176,7 +2177,7 @@ extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
 }
 
 //
-// effects/SkDashPathEffect
+// effects/SkDashPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int count, SkScalar phase) {
@@ -2184,7 +2185,7 @@ extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int
 }
 
 //
-// effects/SkDiscretePathEffect
+// effects/SkDiscretePathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScalar dev, uint32_t seedAssist) {
@@ -2192,7 +2193,7 @@ extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScala
 }
 
 //
-// effects/SkDisplacementMapEffect
+// effects/SkDisplacementMapEffect.h
 //
 
 extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect::ChannelSelectorType xChannelSelector,
@@ -2206,7 +2207,7 @@ extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect
 }
 
 //
-// effects/SkDropShadowImageFilter
+// effects/SkDropShadowImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkDropShadowImageFilter_Make(SkScalar dx, SkScalar dy, SkScalar sigmaX, SkScalar sigmaY,
@@ -2226,7 +2227,7 @@ extern "C" SkColorFilter* C_SkHighContrastFilter_Make(const SkHighContrastConfig
 }
 
 //
-// effects/SkImageSource
+// effects/SkImageSource.h
 //
 
 extern "C" SkImageFilter *C_SkImageSource_Make(SkImage *image) {
@@ -2240,7 +2241,7 @@ C_SkImageSource_Make2(SkImage* image, const SkRect &srcRect, const SkRect &dstRe
 }
 
 //
-// effects/SkLayerDrawLooper
+// effects/SkLayerDrawLooper.h
 //
 
 extern "C" void C_SkLayerDrawLooper_Builder_destruct(SkLayerDrawLooper::Builder* self) {
@@ -2252,7 +2253,7 @@ extern "C" SkDrawLooper* C_SkLayerDrawLooper_Builder_detach(SkLayerDrawLooper::B
 }
 
 //
-// effects/SkLightingImageFilter
+// effects/SkLightingImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2318,7 +2319,7 @@ extern "C" SkColorFilter* C_SkLumaColorFilter_Make() {
 }
 
 //
-// effects/SkMagnifierImageFilter
+// effects/SkMagnifierImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2328,7 +2329,7 @@ C_SkMagnifierImageFilter_Make(const SkRect &srcRect, SkScalar inset, SkImageFilt
 }
 
 //
-// effects/SkMatrixConvolutionImageFilter
+// effects/SkMatrixConvolutionImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2346,7 +2347,7 @@ C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
 }
 
 //
-// effects/SkMergeImageFilter
+// effects/SkMergeImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2361,7 +2362,7 @@ C_SkMergeImageFilter_Make(SkImageFilter *const filters[], int count, const SkIma
 }
 
 //
-// effects/SkMorphologyImageFiter
+// effects/SkMorphologyImageFiter.h
 //
 
 extern "C" SkImageFilter *C_SkDilateImageFilter_Make(int radiusX, int radiusY, SkImageFilter *input,
@@ -2375,7 +2376,7 @@ extern "C" SkImageFilter *C_SkErodeImageFilter_Make(int radiusX, int radiusY, Sk
 }
 
 //
-// effects/SkOffsetImageFilter
+// effects/SkOffsetImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkOffsetImageFilter_Make(SkScalar dx, SkScalar dy, SkImageFilter *input,
@@ -2416,7 +2417,7 @@ extern "C" SkColorFilter* C_SkOverdrawColorFilter_Make(const SkPMColor colors[Sk
 }
 
 //
-// effects/SkPaintImageFilter
+// effects/SkPaintImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const SkImageFilter::CropRect *cropRect) {
@@ -2424,7 +2425,7 @@ extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const 
 }
 
 //
-// effects/SkPictureImageFilter
+// effects/SkPictureImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkPictureImageFilter_Make(SkPicture *picture, const SkRect *cropRect) {
@@ -2445,7 +2446,7 @@ extern "C" SkMaskFilter* C_SkShaderMaskFilter_Make(SkShader* shader) {
 }
 
 //
-// effects/SkTableColorFilter
+// effects/SkTableColorFilter.h
 //
 
 extern "C" SkColorFilter* C_SkTableColorFilter_Make(const uint8_t table[256]) {
@@ -2457,7 +2458,7 @@ extern "C" SkColorFilter* C_SkTableColorFilter_MakeARGB(const uint8_t tableA[256
 }
 
 //
-// effects/SkTileImageFilter
+// effects/SkTileImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRect &dst, SkImageFilter *input) {
@@ -2473,7 +2474,7 @@ extern "C" SkPathEffect *C_SkTrimPathEffect_Make(SkScalar startT, SkScalar stopT
 }
 
 //
-// effects/SkXfermodeImageFilter
+// effects/SkXfermodeImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2483,7 +2484,190 @@ C_SkXfermodeImageFilter_Make(SkBlendMode mode, SkImageFilter *background, SkImag
 }
 
 //
-// docs/SkPDFDocument
+// effects/SkImageFilters.h
+// 
+
+extern "C" {
+
+SkImageFilter *
+C_SkImageFilters_AlphaThreshold(const SkRegion &region, SkScalar innerMin, SkScalar outerMax, SkImageFilter *input,
+                                const SkIRect *cropRect) {
+    return SkImageFilters::AlphaThreshold(region, innerMin, outerMax, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Arithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor,
+                                           SkImageFilter *background,
+                                           SkImageFilter *foreground,
+                                           const SkIRect *cropRect) {
+    return SkImageFilters::Arithmetic(k1, k2, k3, k4, enforcePMColor, sp(background),
+                                      sp(foreground), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Blur(SkScalar sigmaX, SkScalar sigmaY, SkTileMode tileMode,
+                                     SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::Blur(sigmaX, sigmaY, tileMode, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_ColorFilter(SkColorFilter *cf, SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::ColorFilter(sp(cf), sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Compose(SkImageFilter *outer, SkImageFilter *inner) {
+    return SkImageFilters::Compose(sp(outer), sp(inner)).release();
+}
+
+SkImageFilter *C_SkImageFilters_DisplacementMap(SkColorChannel xChannelSelector,
+                                                SkColorChannel yChannelSelector,
+                                                SkScalar scale, SkImageFilter *displacement,
+                                                SkImageFilter *color,
+                                                const SkIRect *cropRect) {
+    return SkImageFilters::DisplacementMap(xChannelSelector, yChannelSelector, scale, sp(displacement), sp(color),
+                                           cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DropShadow(SkScalar dx, SkScalar dy,
+                                           SkScalar sigmaX, SkScalar sigmaY,
+                                           SkColor color, SkImageFilter *input,
+                                           const SkIRect *cropRect) {
+    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DropShadowOnly(SkScalar dx, SkScalar dy,
+                                               SkScalar sigmaX, SkScalar sigmaY,
+                                               SkColor color, SkImageFilter *input,
+                                               const SkIRect *cropRect) {
+    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Image(SkImage *image, const SkRect *srcRect,
+                                      const SkRect *dstRect, SkFilterQuality filterQuality) {
+    return SkImageFilters::Image(sp(image), *srcRect, *dstRect, filterQuality).release();
+}
+
+SkImageFilter *C_SkImageFilters_Magnifier(const SkRect *srcRect, SkScalar inset,
+                                          SkImageFilter *input,
+                                          const SkIRect *cropRect) {
+    return SkImageFilters::Magnifier(*srcRect, inset, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_MatrixConvolution(const SkISize *kernelSize,
+                                                  const SkScalar kernel[], SkScalar gain,
+                                                  SkScalar bias, const SkIPoint *kernelOffset,
+                                                  SkTileMode tileMode, bool convolveAlpha,
+                                                  SkImageFilter *input,
+                                                  const SkIRect *cropRect) {
+    return SkImageFilters::MatrixConvolution(*kernelSize, kernel, gain, bias, *kernelOffset, tileMode, convolveAlpha,
+                                             sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_MatrixTransform(const SkMatrix *matrix,
+                                                SkFilterQuality filterQuality,
+                                                SkImageFilter *input) {
+
+    return SkImageFilters::MatrixTransform(*matrix, filterQuality, sp(input)).release();
+}
+
+SkImageFilter *C_SkImageFilters_Merge(SkImageFilter *const filters[], int count,
+                                      const SkIRect *cropRect) {
+    auto array = new sk_sp<SkImageFilter>[count];
+    for (int i = 0; i < count; ++i) {
+        array[i] = sp(filters[i]);
+    }
+    auto imageFilter = SkImageFilters::Merge(array, count, cropRect).release();
+    delete[] array;
+    return imageFilter;
+}
+
+SkImageFilter *C_SkImageFilters_Offset(SkScalar dx, SkScalar dy, SkImageFilter *input,
+                                       const SkIRect *cropRect) {
+    return SkImageFilters::Offset(dx, dy, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Paint(const SkPaint *paint, const SkIRect *cropRect) {
+    return SkImageFilters::Paint(*paint, cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Picture(SkPicture *pic, const SkRect *targetRect) {
+    return SkImageFilters::Picture(sp(pic), *targetRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Tile(const SkRect *src, const SkRect *dst,
+                                     SkImageFilter *input) {
+    return SkImageFilters::Tile(*src, *dst, sp(input)).release();
+}
+
+SkImageFilter *C_SkImageFilters_Xfermode(SkBlendMode blendMode, SkImageFilter *background,
+                                         SkImageFilter *foreground,
+                                         const SkIRect *cropRect) {
+    return SkImageFilters::Xfermode(blendMode, sp(background), sp(foreground), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Dilate(int radiusX, int radiusY, SkImageFilter *input,
+                                       const SkIRect *cropRect) {
+    return SkImageFilters::Dilate(radiusX, radiusY, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Erode(int radiusX, int radiusY, SkImageFilter *input,
+                                      const SkIRect *cropRect) {
+    return SkImageFilters::Erode(radiusX, radiusY, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DistantLitDiffuse(const SkPoint3 *direction, SkColor lightColor,
+                                                  SkScalar surfaceScale, SkScalar kd,
+                                                  SkImageFilter *input,
+                                                  const SkIRect *cropRect) {
+    return SkImageFilters::DistantLitDiffuse(*direction, lightColor, surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_PointLitDiffuse(const SkPoint3 *direction, SkColor lightColor,
+                                                SkScalar surfaceScale, SkScalar kd,
+                                                SkImageFilter *input,
+                                                const SkIRect *cropRect) {
+    return SkImageFilters::PointLitDiffuse(*direction, lightColor, surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_SpotLitDiffuse(const SkPoint3 *location,
+                                const SkPoint3 *target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                SkColor lightColor, SkScalar surfaceScale, SkScalar kd,
+                                SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::SpotLitDiffuse(*location, *target, specularExponent, cutoffAngle, lightColor,
+                                          surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_ImageFilters_DistantLitSpecular(const SkPoint3 *direction,
+                                  SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                  SkScalar shininess, SkImageFilter *input,
+                                  const SkIRect *cropRect) {
+    return SkImageFilters::DistantLitSpecular(*direction, lightColor, surfaceScale, ks, shininess,
+                                              sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_PointLitSpecular(const SkPoint3 &location,
+                                  SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                  SkScalar shininess, SkImageFilter *input,
+                                  const SkIRect *cropRect) {
+    return SkImageFilters::PointLitSpecular(location, lightColor, surfaceScale, ks, shininess,
+                                            sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_SpotLitSpecular(const SkPoint3 &location,
+                                 const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                 SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                 SkScalar shininess, SkImageFilter *input,
+                                 const SkIRect *cropRect) {
+    return SkImageFilters::SpotLitSpecular(location, target, specularExponent, cutoffAngle, lightColor,
+                                           surfaceScale, ks, shininess, sp(input),
+                                           cropRect).release();
+}
+
+}
+
+//
+// docs/SkPDFDocument.h
 //
 
 extern "C" void C_SkPDF_Metadata_Construct(SkPDF::Metadata* uninitialized) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2773,6 +2773,10 @@ extern "C" void C_GrContext_flush(GrContext* self) {
     self->flush();
 }
 
+extern "C" GrBackendFormat C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable) {
+    return self->defaultBackendFormat(ct, renderable);
+}
+
 //
 // gpu/GrBackendDrawableInfo.h
 //
@@ -2896,19 +2900,6 @@ extern "C" void C_GrVkAlloc_Construct(GrVkAlloc* uninitialized, VkDeviceMemory m
 
 extern "C" bool C_GrVkAlloc_Equals(const GrVkAlloc* lhs, const GrVkAlloc* rhs) {
     return *lhs == *rhs;
-}
-
-extern "C" void C_GrVkYcbcrConversionInfo_Construct(
-        GrVkYcbcrConversionInfo* uninitialized,
-        VkSamplerYcbcrModelConversion ycbcrModel,
-        VkSamplerYcbcrRange ycbcrRange,
-        VkChromaLocation xChromaOffset,
-        VkChromaLocation yChromaOffset,
-        VkFilter chromaFilter,
-        VkBool32 forceExplicitReconstruction,
-        uint64_t externalFormat,
-        VkFormatFeatureFlags externalFormatFeatures) {
-    new (uninitialized) GrVkYcbcrConversionInfo(ycbcrModel, ycbcrRange, xChromaOffset, yChromaOffset, chromaFilter, forceExplicitReconstruction, externalFormat, externalFormatFeatures);
 }
 
 extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* lhs, const GrVkYcbcrConversionInfo* rhs) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2773,8 +2773,8 @@ extern "C" void C_GrContext_flush(GrContext* self) {
     self->flush();
 }
 
-extern "C" GrBackendFormat C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable) {
-    return self->defaultBackendFormat(ct, renderable);
+extern "C" void C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable, GrBackendFormat* result) {
+    *result = self->defaultBackendFormat(ct, renderable);
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -332,6 +332,14 @@ extern "C" SkImage* C_SkImage_MakeFromEncoded(SkData* encoded, const SkIRect* su
     return SkImage::MakeFromEncoded(sp(encoded), subset).release();
 }
 
+extern "C" SkImage* C_SkImage_DecodeToRaster(const void* encoded, size_t length, const SkIRect* subset) {
+    return SkImage::DecodeToRaster(encoded, length, subset).release();
+}
+
+extern "C" SkImage* C_SkImage_DecodeToTexture(GrContext* ctx, const void* encoded, size_t length, const SkIRect* subset) {
+    return SkImage::DecodeToTexture(ctx, encoded, length, subset).release();
+}
+
 extern "C" SkImage* C_SkImage_MakeFromCompressed(GrContext* context, SkData* encoded, int width, int height, SkImage::CompressionType type) {
     return SkImage::MakeFromCompressed(context, sp(encoded), width, height, type).release();
 }
@@ -345,7 +353,15 @@ extern "C" SkImage* C_SkImage_MakeFromTexture(
         SkColorSpace* colorSpace) {
     return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
- 
+
+extern "C" SkImage* C_SkImage_MakeCrossContextFromPixmap(
+        GrContext* context,
+        const SkPixmap* pixmap,
+        bool buildMips,
+        bool limitToMaxTextureSize) {
+    return SkImage::MakeCrossContextFromPixmap(context, *pixmap, buildMips, limitToMaxTextureSize).release();
+}
+
 extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
         GrContext* context,
         const GrBackendTexture* backendTexture,
@@ -483,6 +499,10 @@ extern "C" SkImage *C_SkImage_makeWithFilter(const SkImage *self, GrContext *con
 
 extern "C" SkImage* C_SkImage_makeColorSpace(const SkImage* self, SkColorSpace* target) {
     return self->makeColorSpace(sp(target)).release();
+}
+
+extern "C" SkImage* C_SkImage_reinterpretColorSpace(const SkImage* self, SkColorSpace* newColorSpace) {
+    return self->reinterpretColorSpace(sp(newColorSpace)).release();
 }
 
 //
@@ -1593,6 +1613,10 @@ extern "C" SkColorFilter* C_SkColorFilters_Matrix(const SkColorMatrix* colorMatr
 
 extern "C" SkColorFilter* C_SkColorFilters_MatrixRowMajor(const SkScalar array[20]) {
     return SkColorFilters::Matrix(array).release();
+}
+
+extern "C" SkColorFilter* C_SkColorFilters_HSLAMatrix(const float rowMajor[20]) {
+    return SkColorFilters::HSLAMatrix(rowMajor).release();
 }
 
 extern "C" SkColorFilter* C_SkColorFilters_LinearToSRGBGamma() {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -345,17 +345,7 @@ extern "C" SkImage* C_SkImage_MakeFromTexture(
         SkColorSpace* colorSpace) {
     return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
-
-extern "C" SkImage* C_SkImage_MakeCrossContextFromEncoded(
-        GrContext* context,
-        SkData* data,
-        bool buildMips,
-        const SkColorSpace* dstColorSpace,
-        bool limitToMaxTextureSize
-        ) {
-    return SkImage::MakeCrossContextFromEncoded(context, sp(data), buildMips, const_cast<SkColorSpace*>(dstColorSpace), limitToMaxTextureSize).release();
-}
-
+ 
 extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
         GrContext* context,
         const GrBackendTexture* backendTexture,
@@ -472,9 +462,8 @@ extern "C" SkImage* C_SkImage_makeSubset(const SkImage* self, const SkIRect* sub
 extern "C" SkImage* C_SkImage_makeTextureImage(
         const SkImage* self,
         GrContext* context,
-        const SkColorSpace* dstColorSpace,
         GrMipMapped mipMapped) {
-    return self->makeTextureImage(context, const_cast<SkColorSpace*>(dstColorSpace), mipMapped).release();
+    return self->makeTextureImage(context, mipMapped).release();
 }
 
 extern "C" SkImage* C_SkImage_makeNonTextureImage(const SkImage* self) {
@@ -1100,8 +1089,8 @@ extern "C" bool C_SkRegion_set(SkRegion* self, const SkRegion* region) {
     return self->set(*region);
 }
 
-extern "C" bool C_SkRegion_quickContains(const SkRegion* self, int32_t left, int32_t top, int32_t right, int32_t bottom) {
-    return self->quickContains(left, top, right, bottom);
+extern "C" bool C_SkRegion_quickContains(const SkRegion* self, const SkIRect* r) {
+    return self->quickContains(*r);
 }
 
 extern "C" void C_SkRegion_Iterator_Construct(SkRegion::Iterator* uninitialized) {
@@ -1730,7 +1719,7 @@ extern "C" int C_SkImageFilter_countInputs(const SkImageFilter* self) {
     return self->countInputs();
 }
 
-extern "C" SkImageFilter* C_SkImageFilter_getInput(const SkImageFilter* self, int i) {
+extern "C" const SkImageFilter* C_SkImageFilter_getInput(const SkImageFilter* self, int i) {
     return self->getInput(i);
 }
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -654,10 +654,6 @@ extern "C" void C_SkPath_Iter_destruct(SkPath::Iter* self) {
     self->~Iter();
 }
 
-extern "C" SkPath::Verb C_SkPath_Iter_next(SkPath::Iter* self, SkPoint pts[4], bool doConsumeDegenerates, bool exact) {
-    return self->next(pts, doConsumeDegenerates, exact);
-}
-
 extern "C" bool C_SkPath_Iter_isCloseLine(const SkPath::Iter* self) {
     return self->isCloseLine();
 }

--- a/skia-bindings/src/bindings.h
+++ b/skia-bindings/src/bindings.h
@@ -1,0 +1,11 @@
+#ifndef SKIA_BINDINGS_BINDINGS_H
+#define SKIA_BINDINGS_BINDINGS_H
+
+#include "include/core/SkRefCnt.h"
+
+template<typename T>
+inline sk_sp<T> spFromConst(const T* pt) {
+    return sk_sp<T>(const_cast<T*>(pt));
+}
+
+#endif //SKIA_BINDINGS_BINDINGS_H

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,53 +1,56 @@
 //! This file contains Default trait implementations for types that are
 //! used without a handle in skia-safe and get reexported from there.
 
-impl Default for crate::skia_textlayout_Affinity {
-    fn default() -> Self {
-        Self::Upstream
-    }
-}
-
-impl Default for crate::skia_textlayout_RectHeightStyle {
-    fn default() -> Self {
-        Self::Tight
-    }
-}
-
-impl Default for crate::skia_textlayout_RectWidthStyle {
-    fn default() -> Self {
-        Self::Tight
-    }
-}
-
-impl Default for crate::skia_textlayout_TextAlign {
-    fn default() -> Self {
-        Self::Left
-    }
-}
-
-impl Default for crate::skia_textlayout_PositionWithAffinity {
-    fn default() -> Self {
-        Self {
-            position: 0,
-            affinity: Default::default(),
+#[cfg(feature = "textlayout")]
+pub mod textlayout {
+    impl Default for crate::skia_textlayout_Affinity {
+        fn default() -> Self {
+            Self::Upstream
         }
     }
-}
 
-impl Default for crate::skia_textlayout_TextBaseline {
-    fn default() -> Self {
-        Self::Alphabetic
+    impl Default for crate::skia_textlayout_RectHeightStyle {
+        fn default() -> Self {
+            Self::Tight
+        }
     }
-}
 
-impl Default for crate::skia_textlayout_TextDecorationStyle {
-    fn default() -> Self {
-        Self::Solid
+    impl Default for crate::skia_textlayout_RectWidthStyle {
+        fn default() -> Self {
+            Self::Tight
+        }
     }
-}
 
-impl Default for crate::skia_textlayout_StyleType {
-    fn default() -> Self {
-        Self::AllAttributes
+    impl Default for crate::skia_textlayout_TextAlign {
+        fn default() -> Self {
+            Self::Left
+        }
+    }
+
+    impl Default for crate::skia_textlayout_PositionWithAffinity {
+        fn default() -> Self {
+            Self {
+                position: 0,
+                affinity: Default::default(),
+            }
+        }
+    }
+
+    impl Default for crate::skia_textlayout_TextBaseline {
+        fn default() -> Self {
+            Self::Alphabetic
+        }
+    }
+
+    impl Default for crate::skia_textlayout_TextDecorationStyle {
+        fn default() -> Self {
+            Self::Solid
+        }
+    }
+
+    impl Default for crate::skia_textlayout_StyleType {
+        fn default() -> Self {
+            Self::AllAttributes
+        }
     }
 }

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,0 +1,1 @@
+//! Default implementation for enums that are used in skia-safe and exported from there.

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -53,4 +53,10 @@ pub mod textlayout {
             Self::AllAttributes
         }
     }
+
+    impl Default for crate::skia_textlayout_PlaceholderAlignment {
+        fn default() -> Self {
+            Self::Baseline
+        }
+    }
 }

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,1 +1,53 @@
-//! Default implementation for enums that are used in skia-safe and exported from there.
+//! This file contains Default trait implementations for types that are
+//! used without a handle in skia-safe and get reexported from there.
+
+impl Default for crate::skia_textlayout_Affinity {
+    fn default() -> Self {
+        Self::Upstream
+    }
+}
+
+impl Default for crate::skia_textlayout_RectHeightStyle {
+    fn default() -> Self {
+        Self::Tight
+    }
+}
+
+impl Default for crate::skia_textlayout_RectWidthStyle {
+    fn default() -> Self {
+        Self::Tight
+    }
+}
+
+impl Default for crate::skia_textlayout_TextAlign {
+    fn default() -> Self {
+        Self::Left
+    }
+}
+
+impl Default for crate::skia_textlayout_PositionWithAffinity {
+    fn default() -> Self {
+        Self {
+            position: 0,
+            affinity: Default::default(),
+        }
+    }
+}
+
+impl Default for crate::skia_textlayout_TextBaseline {
+    fn default() -> Self {
+        Self::Alphabetic
+    }
+}
+
+impl Default for crate::skia_textlayout_TextDecorationStyle {
+    fn default() -> Self {
+        Self::Solid
+    }
+}
+
+impl Default for crate::skia_textlayout_StyleType {
+    fn default() -> Self {
+        Self::AllAttributes
+    }
+}

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -5,5 +5,8 @@
 mod bindings;
 pub use bindings::*;
 
+mod defaults;
+pub use defaults::*;
+
 #[cfg(feature = "shaper")]
 pub mod icu;

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -1,1 +1,259 @@
 /// Skia skparagraph Module C Wrapper Functions
+
+#include "bindings.h"
+
+#include "modules/skparagraph/include/DartTypes.h"
+#include "modules/skparagraph/include/FontCollection.h"
+#include "modules/skparagraph/include/Paragraph.h"
+#include "modules/skparagraph/include/ParagraphBuilder.h"
+#include "modules/skparagraph/include/ParagraphStyle.h"
+#include "modules/skparagraph/include/TextShadow.h"
+#include "modules/skparagraph/include/TextStyle.h"
+#include "modules/skparagraph/include/TypefaceFontProvider.h"
+
+using namespace skia::textlayout;
+
+//
+// FontCollection.h
+//
+
+extern "C" {
+
+    void C_FontCollection_setAssetFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setAssetFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDynamicFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setDynamicFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setTestFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setTestFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDefaultFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setDefaultFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDefaultFontManager2(FontCollection* self, const SkFontMgr* fontManager, const char* defaultFamilyName) {
+        self->setDefaultFontManager(spFromConst(fontManager), defaultFamilyName);
+    }
+
+    SkFontMgr* C_FontCollection_getFallbackManager(const FontCollection* self) {
+        return self->geFallbackManager().release();
+    }
+
+    SkTypeface* C_FontCollection_matchTypeface(FontCollection* self, const char* familyName, SkFontStyle fontStyle) {
+        return self->matchTypeface(familyName, fontStyle).release();
+    }
+
+    SkTypeface* C_FontCollection_matchDefaultTypeface(FontCollection* self, SkFontStyle fontStyle) {
+        return self->matchDefaultTypeface(fontStyle).release();
+    }
+
+    SkTypeface* C_FontCollection_defaultFallback(FontCollection* self, SkUnichar unicode, SkFontStyle fontStyle, const SkString* locale) {
+        return self->defaultFallback(unicode, fontStyle, *locale).release();
+    }
+}
+
+//
+// ParagraphStyle.h
+//
+
+extern "C" {
+    void C_StrutStyle_assign(StrutStyle* self, const StrutStyle* other) {
+        *self = *other;
+    }
+
+    void C_StrutStyle_destruct(StrutStyle* self) {
+        self->~StrutStyle();
+    }
+
+    const SkString* C_StrutStyle_getFontFamilies(const StrutStyle* self, size_t* count) {
+        auto& v = self->getFontFamilies();
+        *count = v.size();
+        return v.data();
+    }
+
+    void C_StrutStyle_setFontFamilies(StrutStyle* self, const SkString* data, size_t count) {
+        self->setFontFamilies(std::vector<SkString>(data, data + count));
+    }
+}
+
+extern "C" {
+    bool C_ParagraphStyle_Equals(const ParagraphStyle* left, const ParagraphStyle* right) {
+        return *left == *right;
+    }
+
+    void C_ParagraphStyle_setStrutStyle(ParagraphStyle* self, const StrutStyle* strutStyle) {
+        self->setStrutStyle(*strutStyle);
+    }
+
+    void C_ParagraphStyle_setEllipsis(ParagraphStyle* self, const StrutStyle* strutStyle) {
+        self->setStrutStyle(*strutStyle);
+    }
+}
+
+//
+// TextShadow.h
+//
+
+extern "C" {
+    void C_TextShadow_destruct(TextShadow* self) {
+        self->~TextShadow();
+    }
+}
+
+//
+// Paragraph.h
+//
+
+struct TextBoxes {
+    std::vector<TextBox> textBoxes;
+};
+
+extern "C" {
+    void C_TextBoxes_destruct(TextBoxes* self) {
+        self->~TextBoxes();
+    }
+
+    const TextBox* C_TextBoxes_ptr(TextBoxes* boxes) {
+        return &boxes->textBoxes.front();
+    }
+
+    size_t C_TextBoxes_count(const TextBoxes* boxes) {
+        return boxes->textBoxes.size();
+    }
+}
+
+extern "C" {
+    void C_Paragraph_delete(Paragraph* self) {
+        delete self;
+    }
+
+    bool C_Paragraph_didExceedMaxLines(Paragraph* self) {
+        return self->didExceedMaxLines();
+    }
+
+    void C_Paragraph_layout(Paragraph* self, SkScalar width) {
+        self->layout(width);
+    }
+
+    void C_Paragraph_paint(Paragraph* self, SkCanvas* canvas, SkScalar x, SkScalar y) {
+        self->paint(canvas, x, y);
+    }
+
+    void C_Paragraph_getRectsForRange(Paragraph *self, unsigned start, unsigned end, RectHeightStyle rectHeightStyle,
+                                            RectWidthStyle rectWidthStyle, TextBoxes* uninitialized) {
+        auto v = self->getRectsForRange(start, end, rectHeightStyle, rectWidthStyle);
+        new(uninitialized) TextBoxes{std::move(v)};
+    }
+
+    void C_Paragraph_getGlyphPositionAtCoordinate(Paragraph* self, SkScalar x, SkScalar y, PositionWithAffinity* position) {
+        *position = self->getGlyphPositionAtCoordinate(x, y);
+    }
+
+    void C_Paragraph_getWordBoundary(Paragraph* self, unsigned offset, size_t range[2]) {
+        auto sk_range = self->getWordBoundary(offset);
+        range[0] = sk_range.start;
+        range[1] = sk_range.end;
+    }
+
+    size_t C_Paragraph_lineNumber(Paragraph* self) {
+        return self->lineNumber();
+    }
+
+    void C_Paragraph_markDirty(Paragraph* self) {
+        self->markDirty();
+    }
+}
+
+//
+// ParagraphBuilder.h
+//
+
+extern "C" {
+    void C_ParagraphBuilder_delete(ParagraphBuilder* self) {
+        delete self;
+    }
+
+    void C_ParagraphBuilder_pushStyle(ParagraphBuilder* self, const TextStyle* style) {
+        self->pushStyle(*style);
+    }
+
+    void C_ParagraphBuilder_pop(ParagraphBuilder* self) {
+        self->pop();
+    }
+
+    void C_ParagraphBuilder_peekStyle(ParagraphBuilder* self, TextStyle* style) {
+        *style = self->peekStyle();
+    }
+
+    void C_ParagraphBuilder_addText(ParagraphBuilder* self, const char* text) {
+        self->addText(text);
+    }
+
+    void C_ParagraphBuilder_setParagraphStyle(ParagraphBuilder* self, const ParagraphStyle* style) {
+        self->setParagraphStyle(*style);
+    }
+
+    Paragraph* C_ParagraphBuilder_Build(ParagraphBuilder* self) {
+        return self->Build().release();
+    }
+
+    ParagraphBuilder* C_ParagraphBuilder_make(const ParagraphStyle* style, const FontCollection* fontCollection) {
+        return ParagraphBuilder::make(*style, spFromConst(fontCollection)).release();
+    }
+}
+
+//
+// TextStyle.h
+//
+
+extern "C" {
+    void C_TextStyle_assign(TextStyle* self, const TextStyle* other) {
+        *self = *other;
+    }
+
+    void C_TextStyle_destruct(TextStyle* self) {
+        self->~TextStyle();
+    }
+
+    size_t C_TextStyle_getShadowNumber(const TextStyle* self) {
+        return self->getShadowNumber();
+    }
+
+    void C_TextStyle_getShadows(const TextStyle* self, TextShadow shadowsOut[]) {
+        auto shadows = self->getShadows();
+        for(std::vector<TextShadow>::size_type i = 0; i != shadows.size(); ++i) {
+            shadowsOut[i] = shadows[i];
+        }
+    }
+
+    void C_TextStyle_addShadow(TextStyle* self, const TextShadow* shadow) {
+        self->addShadow(*shadow);
+    }
+
+    void C_TextStyle_resetShadows(TextStyle* self) {
+        self->resetShadows();
+    }
+
+    const SkString* C_TextStyle_getFontFamilies(const TextStyle* self, size_t* count) {
+        auto& v = self->getFontFamilies();
+        *count = v.size();
+        return v.data();
+    }
+
+    void C_TextStyle_setFontFamilies(TextStyle* self, const SkString* data, size_t count) {
+        self->setFontFamilies(std::vector<SkString>(data, data + count));
+    }
+
+    void C_TextStyle_setTypeface(TextStyle* self, const SkTypeface* typeface) {
+        self->setTypeface(spFromConst(typeface));
+    }
+
+    void C_TextStyle_getFontMetrics(const TextStyle* self, SkFontMetrics* metrics) {
+        self->getFontMetrics(metrics);
+    }
+}
+

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -4,6 +4,7 @@
 
 #include "modules/skparagraph/include/DartTypes.h"
 #include "modules/skparagraph/include/FontCollection.h"
+#include "modules/skparagraph/include/ParagraphCache.h"
 #include "modules/skparagraph/include/Paragraph.h"
 #include "modules/skparagraph/include/ParagraphBuilder.h"
 #include "modules/skparagraph/include/ParagraphStyle.h"
@@ -58,8 +59,30 @@ extern "C" {
         return self->defaultFallback(unicode, fontStyle, *locale).release();
     }
 
+    SkTypeface* C_FontCollection_defaultFallback2(FontCollection* self) {
+        return self->defaultFallback().release();
+    }
+
     bool C_FontCollection_fontFallbackEnabled(const FontCollection* self) {
         return const_cast<FontCollection*>(self)->fontFallbackEnabled();
+    }
+
+    ParagraphCache* C_FontCollection_paragraphCache(FontCollection* self) {
+        return self->getParagraphCache();
+    }
+}
+
+//
+// ParagraphCache.h
+//
+
+extern "C" {
+    void C_ParagraphCache_destruct(ParagraphCache* self) {
+        self->~ParagraphCache();
+    }
+
+    int C_ParagraphCache_count(ParagraphCache* self) {
+        return self->count();
     }
 }
 
@@ -153,6 +176,11 @@ extern "C" {
         new(uninitialized) TextBoxes{std::move(v)};
     }
 
+    void C_Paragraph_GetRectsForPlaceholders(Paragraph* self, TextBoxes* uninitialized) {
+        auto v = self->GetRectsForPlaceholders();
+        new(uninitialized) TextBoxes{std::move(v)};
+    }
+
     void C_Paragraph_getGlyphPositionAtCoordinate(Paragraph* self, SkScalar x, SkScalar y, PositionWithAffinity* position) {
         *position = self->getGlyphPositionAtCoordinate(x, y);
     }
@@ -195,6 +223,10 @@ extern "C" {
 
     void C_ParagraphBuilder_addText(ParagraphBuilder* self, const char* text) {
         self->addText(text);
+    }
+
+    void C_ParagraphBuilder_addPlaceholder(ParagraphBuilder* self, const PlaceholderStyle* placeholderStyle) {
+        self->addPlaceholder(*placeholderStyle);
     }
 
     void C_ParagraphBuilder_setParagraphStyle(ParagraphBuilder* self, const ParagraphStyle* style) {
@@ -243,10 +275,6 @@ extern "C" {
 
     void C_TextStyle_setTypeface(TextStyle* self, SkTypeface* typeface) {
         self->setTypeface(sk_sp<SkTypeface>(typeface));
-    }
-
-    void C_TextStyle_getFontMetrics(const TextStyle* self, SkFontMetrics* metrics) {
-        self->getFontMetrics(metrics);
     }
 }
 

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -281,6 +281,6 @@ extern "C" {
         if (alias) {
             return self->registerTypeface(sk_sp<SkTypeface>(typeface), *alias);
         }
-        self->registerTypeface(sk_sp<SkTypeface>(typeface));
+        return self->registerTypeface(sk_sp<SkTypeface>(typeface));
     }
 }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -57,6 +57,10 @@ extern "C" {
     SkTypeface* C_FontCollection_defaultFallback(FontCollection* self, SkUnichar unicode, SkFontStyle fontStyle, const SkString* locale) {
         return self->defaultFallback(unicode, fontStyle, *locale).release();
     }
+
+    bool C_FontCollection_fontFallbackEnabled(const FontCollection* self) {
+        return const_cast<FontCollection*>(self)->fontFallbackEnabled();
+    }
 }
 
 //

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -46,12 +46,12 @@ extern "C" {
         return self->geFallbackManager().release();
     }
 
-    SkTypeface* C_FontCollection_matchTypeface(FontCollection* self, const char* familyName, SkFontStyle fontStyle) {
-        return self->matchTypeface(familyName, fontStyle).release();
+    SkTypeface* C_FontCollection_matchTypeface(FontCollection* self, const char* familyName, SkFontStyle fontStyle, const SkString* locale) {
+        return self->matchTypeface(familyName, fontStyle, *locale).release();
     }
 
-    SkTypeface* C_FontCollection_matchDefaultTypeface(FontCollection* self, SkFontStyle fontStyle) {
-        return self->matchDefaultTypeface(fontStyle).release();
+    SkTypeface* C_FontCollection_matchDefaultTypeface(FontCollection* self, SkFontStyle fontStyle, const SkString* locale) {
+        return self->matchDefaultTypeface(fontStyle, *locale).release();
     }
 
     SkTypeface* C_FontCollection_defaultFallback(FontCollection* self, SkUnichar unicode, SkFontStyle fontStyle, const SkString* locale) {

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -18,6 +18,9 @@ using namespace skia::textlayout;
 //
 
 extern "C" {
+    FontCollection* C_FontCollection_new() {
+        return new FontCollection();
+    }
 
     void C_FontCollection_setAssetFontManager(FontCollection* self, const SkFontMgr* fontManager) {
         self->setAssetFontManager(spFromConst(fontManager));

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -5,16 +5,20 @@ extern "C" SkShaper* C_SkShaper_MakePrimitive() {
     return SkShaper::MakePrimitive().release();
 }
 
-extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper() {
-    return SkShaper::MakeShaperDrivenWrapper().release();
+extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShaperDrivenWrapper(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
-extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap() {
-    return SkShaper::MakeShapeThenWrap().release();
+extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShapeThenWrap(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
-extern "C" SkShaper* C_SkShaper_Make() {
-    return SkShaper::Make().release();
+extern "C" SkShaper* C_SkShaper_MakeShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShapeDontWrapOrReorder(sk_sp<SkFontMgr>(fontMgr)).release();
+}
+
+extern "C" SkShaper* C_SkShaper_Make(SkFontMgr* fontMgr) {
+    return SkShaper::Make(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
 extern "C" void C_SkShaper_delete(SkShaper* self) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-
 [features]
 default = []
 vulkan = ["skia-bindings/vulkan"]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -15,6 +15,10 @@ version = "0.18.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
+[lib]
+doctest = false
+
+
 [features]
 default = []
 vulkan = ["skia-bindings/vulkan"]
@@ -34,3 +38,5 @@ offscreen_gl_context = "0.25.0"
 sparkle = "0.1.4"
 clap = "2.33.0"
 ash = "0.29"
+serial_test = "0.2"
+serial_test_derive = "0.2"

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -14,6 +14,8 @@ mod artifact;
 mod drivers;
 mod skcanvas_overview;
 mod skpaint_overview;
+#[cfg(feature = "textlayout")]
+mod skparagraph_example;
 mod skpath_overview;
 #[cfg(feature = "shaper")]
 mod skshaper_example;
@@ -119,6 +121,9 @@ fn main() {
 
         #[cfg(feature = "shaper")]
         skshaper_example::draw::<Driver>(&out_path);
+
+        #[cfg(feature = "textlayout")]
+        skparagraph_example::draw::<Driver>(&out_path);
     }
 }
 

--- a/skia-safe/examples/skia-org/skparagraph_example.rs
+++ b/skia-safe/examples/skia-org/skparagraph_example.rs
@@ -12,17 +12,26 @@ pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
 }
 
 fn draw_lorem_ipsum(canvas: &mut Canvas) {
-    let mut font_collection = FontCollection::new();
-    font_collection.set_default_font_manager(FontMgr::new(), None);
-    let paragraph_style = ParagraphStyle::new();
-    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
-    let mut ts = TextStyle::new();
-    ts.set_foreground_color(Paint::default());
-    paragraph_builder.push_style(&ts);
-    paragraph_builder.add_text(LOREM_IPSUM);
-    let mut paragraph = paragraph_builder.build();
-    paragraph.layout(256.0);
-    paragraph.paint(canvas, Point::default());
+    for _i in 0..1 {
+        let mut font_collection = FontCollection::new();
+        font_collection.set_default_font_manager(FontMgr::new(), None);
+
+        // As of Skia: 6d1c0d4196f19537cc64f74bacc7d123de3be454
+        // 1000 runs of this function can be used to reliably reproduce a crash on macOS with a segmentation
+        // fault if font fallback is not disabled in the font collection.
+        // For more information: https://github.com/pragmatrix/rust-skia/pull/2#issuecomment-531819718
+        font_collection.disable_font_fallback();
+
+        let paragraph_style = ParagraphStyle::new();
+        let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+        let mut ts = TextStyle::new();
+        ts.set_foreground_color(Paint::default());
+        paragraph_builder.push_style(&ts);
+        paragraph_builder.add_text(LOREM_IPSUM);
+        let mut paragraph = paragraph_builder.build();
+        paragraph.layout(256.0);
+        paragraph.paint(canvas, Point::default());
+    }
 }
 
 static LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at leo at nulla tincidunt placerat. Proin eget purus augue. Quisque et est ullamcorper, pellentesque felis nec, pulvinar massa. Aliquam imperdiet, nulla ut dictum euismod, purus dui pulvinar risus, eu suscipit elit neque ac est. Nullam eleifend justo quis placerat ultricies. Vestibulum ut elementum velit. Praesent et dolor sit amet purus bibendum mattis. Aliquam erat volutpat.";

--- a/skia-safe/examples/skia-org/skparagraph_example.rs
+++ b/skia-safe/examples/skia-org/skparagraph_example.rs
@@ -1,0 +1,28 @@
+use crate::artifact::DrawingDriver;
+use skia_safe::textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle};
+use skia_safe::{icu, Canvas, FontMgr, Paint, Point};
+use std::path;
+
+pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
+    let path = path.join("SkParagraph-Example");
+
+    icu::init();
+
+    Driver::draw_image_256(&path, "lorem-ipsum", draw_lorem_ipsum);
+}
+
+fn draw_lorem_ipsum(canvas: &mut Canvas) {
+    let mut font_collection = FontCollection::new();
+    font_collection.set_default_font_manager(FontMgr::new(), None);
+    let paragraph_style = ParagraphStyle::new();
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+    let mut ts = TextStyle::new();
+    ts.set_foreground_color(Paint::default());
+    paragraph_builder.push_style(&ts);
+    paragraph_builder.add_text(LOREM_IPSUM);
+    let mut paragraph = paragraph_builder.build();
+    paragraph.layout(256.0);
+    paragraph.paint(canvas, Point::default());
+}
+
+static LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at leo at nulla tincidunt placerat. Proin eget purus augue. Quisque et est ullamcorper, pellentesque felis nec, pulvinar massa. Aliquam imperdiet, nulla ut dictum euismod, purus dui pulvinar risus, eu suscipit elit neque ac est. Nullam eleifend justo quis placerat ultricies. Vestibulum ut elementum velit. Praesent et dolor sit amet purus bibendum mattis. Aliquam erat volutpat.";

--- a/skia-safe/examples/skia-org/skparagraph_example.rs
+++ b/skia-safe/examples/skia-org/skparagraph_example.rs
@@ -1,4 +1,4 @@
-use crate::artifact::DrawingDriver;
+use crate::DrawingDriver;
 use skia_safe::textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle};
 use skia_safe::{icu, Canvas, FontMgr, Paint, Point};
 use std::path;

--- a/skia-safe/examples/skia-org/skshaper_example.rs
+++ b/skia-safe/examples/skia-org/skshaper_example.rs
@@ -20,7 +20,7 @@ fn draw_rtl_shaped(canvas: &mut Canvas) {
 
     let font = &Font::from_typeface(Typeface::default(), 64.0);
 
-    let shaper = Shaper::new();
+    let shaper = Shaper::new(None);
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -146,17 +146,11 @@ pub use image_encoder::*;
 pub mod image_filter;
 #[deprecated(since = "0.12.0", note = "use image_filter::crop_rect::CropEdge")]
 pub use image_filter::crop_rect::CropEdge as ImageFilterCropRectCropEdge;
-#[deprecated(since = "0.12.0", note = "use image_filter::Context")]
-pub use image_filter::Context as ImageFilterContext;
 #[deprecated(since = "0.12.0", note = "use image_filter::CropRect")]
 pub use image_filter::CropRect as ImageFilterCropRect;
 pub use image_filter::ImageFilter;
 #[deprecated(since = "0.12.0", note = "use image_filter::MapDirection")]
 pub use image_filter::MapDirection as ImageFilterMapDirection;
-#[deprecated(since = "0.12.0", note = "use image_filter::OutputProperties")]
-pub use image_filter::OutputProperties as ImageFilterOutputProperties;
-#[deprecated(since = "0.12.0", note = "use image_filter::TileUsage")]
-pub use image_filter::TileUsage as ImageFilterTileUsage;
 
 mod image_generator;
 pub use image_generator::*;
@@ -346,7 +340,7 @@ pub use vertices::VertexMode as VerticesVertexMode;
 pub use vertices::Vertices;
 
 pub mod yuva_index;
-pub use yuva_index::{ColorChannel, YUVAIndex};
+pub use yuva_index::YUVAIndex;
 
 mod yuva_size_info;
 pub use yuva_size_info::*;

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::u8cpu;
 use skia_bindings as sb;
-use skia_bindings::{SkColor, SkColor4f, SkHSVToColor, SkPMColor, SkRGBToHSV};
+use skia_bindings::{SkColor, SkColor4f, SkColorChannel, SkHSVToColor, SkPMColor, SkRGBToHSV};
 use std::ops::{BitAnd, BitOr, Index, IndexMut, Mul};
 
 // TODO: What should we do with SkAlpha?
@@ -192,6 +192,21 @@ pub fn pre_multiply_argb(a: u8cpu, r: u8cpu, g: u8cpu, b: u8cpu) -> PMColor {
 
 pub fn pre_multiply_color(c: impl Into<Color>) -> PMColor {
     unsafe { sb::SkPreMultiplyColor(c.into().into_native()) }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ColorChannel {
+    R = SkColorChannel::kR as _,
+    G = SkColorChannel::kG as _,
+    B = SkColorChannel::kB as _,
+    A = SkColorChannel::kA as _,
+}
+
+impl NativeTransmutable<SkColorChannel> for ColorChannel {}
+#[test]
+fn color_channel_layout() {
+    ColorChannel::test_layout()
 }
 
 // decided not to directly support SkRGBA4f for now because of the

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -106,6 +106,11 @@ pub mod color_filters {
             .unwrap()
     }
 
+    pub fn hsla_matrix(row_major: &[f32; 20]) -> ColorFilter {
+        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_HSLAMatrix(row_major.as_ptr()) })
+            .unwrap()
+    }
+
     pub fn blend(c: impl Into<Color>, mode: BlendMode) -> Option<ColorFilter> {
         ColorFilter::from_ptr(unsafe {
             sb::C_SkColorFilters_Blend(c.into().into_native(), mode.into_native())

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -119,6 +119,10 @@ impl Handle<SkFont> {
         self.has_flag(sb::SkFont_PrivFlags_kEmbolden_PrivFlag)
     }
 
+    pub fn is_baseline_snap(&self) -> bool {
+        self.has_flag(sb::SkFont_PrivFlags_kBaselineSnap_PrivFlag)
+    }
+
     fn has_flag(&self, flag: SkFont_PrivFlags) -> bool {
         (SkFont_PrivFlags::from(self.native().fFlags) & flag) != 0
     }
@@ -150,6 +154,11 @@ impl Handle<SkFont> {
 
     pub fn set_embolden(&mut self, embolden: bool) -> &mut Self {
         unsafe { self.native_mut().setEmbolden(embolden) }
+        self
+    }
+
+    pub fn set_baseline_snap(&mut self, baseline_snap: bool) -> &mut Self {
+        unsafe { self.native_mut().setBaselineSnap(baseline_snap) }
         self
     }
 

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -197,25 +197,31 @@ impl RCHandle<SkFontMgr> {
     // TODO: makeFromStream(.., ttcIndex).
 }
 
-#[test]
-fn create_all_typefaces() {
-    let font_mgr = FontMgr::default();
-    let families = font_mgr.count_families();
-    println!("FontMgr families: {}", families);
-    // test requires that the font manager returns at least one family for now.
-    assert!(families > 0);
-    // print all family names and styles
-    for i in 0..families {
-        let name = font_mgr.family_name(i);
-        println!("font_family: {}", name);
-        let mut style_set = font_mgr.new_styleset(i);
-        for style_index in 0..style_set.count() {
-            let (_, style_name) = style_set.style(style_index);
-            if let Some(style_name) = style_name {
-                println!("  style: {}", style_name);
+#[cfg(test)]
+mod tests {
+    use crate::FontMgr;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn create_all_typefaces() {
+        let font_mgr = FontMgr::default();
+        let families = font_mgr.count_families();
+        println!("FontMgr families: {}", families);
+        // test requires that the font manager returns at least one family for now.
+        assert!(families > 0);
+        // print all family names and styles
+        for i in 0..families {
+            let name = font_mgr.family_name(i);
+            println!("font_family: {}", name);
+            let mut style_set = font_mgr.new_styleset(i);
+            for style_index in 0..style_set.count() {
+                let (_, style_name) = style_set.style(style_index);
+                if let Some(style_name) = style_name {
+                    println!("  style: {}", style_name);
+                }
+                let face = style_set.new_typeface(style_index);
+                drop(face);
             }
-            let face = style_set.new_typeface(style_index);
-            drop(face);
         }
     }
 }

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -95,6 +95,31 @@ impl RCHandle<SkImage> {
         })
     }
 
+    pub fn decode_to_raster(encoded: &[u8], subset: impl Into<Option<IRect>>) -> Option<Image> {
+        Image::from_ptr(unsafe {
+            sb::C_SkImage_DecodeToRaster(
+                encoded.as_ptr() as _,
+                encoded.len(),
+                subset.into().into_native().as_ptr_or_null(),
+            )
+        })
+    }
+
+    pub fn decode_to_texture(
+        context: &mut gpu::Context,
+        encoded: &[u8],
+        subset: impl Into<Option<IRect>>,
+    ) -> Option<Image> {
+        Image::from_ptr(unsafe {
+            sb::C_SkImage_DecodeToTexture(
+                context.native_mut(),
+                encoded.as_ptr() as _,
+                encoded.len(),
+                subset.into().into_native().as_ptr_or_null(),
+            )
+        })
+    }
+
     // TODO: this is experimental, should probably be removed.
     pub fn from_compressed(
         context: &mut gpu::Context,
@@ -136,27 +161,21 @@ impl RCHandle<SkImage> {
         })
     }
 
-    pub fn from_encoded_cross_context(
+    pub fn from_pixmap_cross_context(
         context: &mut gpu::Context,
-        data: Data,
+        pixmap: &Pixmap,
         build_mips: bool,
-        // not mentions in the docs, but implementation indicates that
-        // this can be null.
-        color_space: Option<&ColorSpace>,
         limit_to_max_texture_size: impl Into<Option<bool>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
-            sb::C_SkImage_MakeCrossContextFromEncoded(
+            sb::C_SkImage_MakeCrossContextFromPixmap(
                 context.native_mut(),
-                data.into_ptr(),
+                pixmap.native(),
                 build_mips,
-                color_space.native_ptr_or_null(),
-                limit_to_max_texture_size.into().unwrap_or_default(),
+                limit_to_max_texture_size.into().unwrap_or(false),
             )
         })
     }
-
-    // TODO: MakeCrossContextFromPixmap()
 
     pub fn from_adopted_texture(
         context: &mut gpu::Context,
@@ -211,6 +230,7 @@ impl RCHandle<SkImage> {
         image_origin: gpu::SurfaceOrigin,
         backend_texture: &gpu::BackendTexture,
         image_color_space: impl Into<Option<ColorSpace>>,
+        // TODO: m78 introduced textureReleaseProc and releaseContext here.
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             sb::C_SkImage_MakeFromYUVATexturesCopyWithExternalBackend(
@@ -275,6 +295,7 @@ impl RCHandle<SkImage> {
         image_origin: gpu::SurfaceOrigin,
         backend_texture: &gpu::BackendTexture,
         image_color_space: impl Into<Option<ColorSpace>>,
+        // TODO: m78 introduced textureReleaseProc and releaseContext here.
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             sb::C_SkImage_MakeFromNV12TexturesCopyWithExternalBackend(
@@ -469,14 +490,12 @@ impl RCHandle<SkImage> {
     pub fn new_texture_image<'a>(
         &self,
         context: &mut gpu::Context,
-        dst_color_space: impl Into<Option<&'a ColorSpace>>,
         mip_mapped: gpu::MipMapped,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             sb::C_SkImage_makeTextureImage(
                 self.native(),
                 context.native_mut(),
-                dst_color_space.into().native_ptr_or_null(),
                 mip_mapped.into_native(),
             )
         })
@@ -524,6 +543,12 @@ impl RCHandle<SkImage> {
     pub fn new_color_space(&self, color_space: impl Into<Option<ColorSpace>>) -> Option<Image> {
         Image::from_ptr(unsafe {
             sb::C_SkImage_makeColorSpace(self.native(), color_space.into().into_ptr_or_null())
+        })
+    }
+
+    pub fn reinterpret_color_space(&self, new_color_space: ColorSpace) -> Option<Image> {
+        Image::from_ptr(unsafe {
+            sb::C_SkImage_reinterpretColorSpace(self.native(), new_color_space.into_ptr())
         })
     }
 }

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -487,7 +487,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe { sb::C_SkImage_makeSubset(self.native(), rect.as_ref().native()) })
     }
 
-    pub fn new_texture_image<'a>(
+    pub fn new_texture_image(
         &self,
         context: &mut gpu::Context,
         mip_mapped: gpu::MipMapped,

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -196,7 +196,7 @@ impl RCHandle<SkImageFilter> {
         })
     }
 
-    #[deprecated(since = "m78", note = "use image_filters::matrix_transform()")]
+    #[deprecated(since = "0.0.0", note = "use image_filters::matrix_transform()")]
     pub fn with_matrix(self, matrix: &Matrix, quality: FilterQuality) -> ImageFilter {
         ImageFilter::from_ptr(unsafe {
             sb::C_SkImageFilter_MakeMatrixFilter(

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 77;
+pub const MILESTONE: usize = 78;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -178,20 +178,10 @@ impl<'a> Iter<'a> {
         r
     }
 
-    pub fn next(
-        &mut self,
-        do_consume_generates: impl Into<Option<bool>>,
-        exact: impl Into<Option<bool>>,
-    ) -> (Verb, Vec<Point>) {
+    pub fn next(&mut self) -> (Verb, Vec<Point>) {
         let mut points = [Point::default(); Verb::MAX_POINTS];
-        let verb = Verb::from_native(unsafe {
-            sb::C_SkPath_Iter_next(
-                self.native_mut(),
-                points.native_mut().as_mut_ptr(),
-                do_consume_generates.into().unwrap_or(true),
-                exact.into().unwrap_or(false),
-            )
-        });
+        let verb =
+            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
         (verb, points[0..verb.points()].into())
     }
 
@@ -216,7 +206,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (Verb, Vec<Point>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (verb, points) = self.next(None, None);
+        let (verb, points) = self.next();
         if verb != Verb::Done {
             Some((verb, points))
         } else {

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -178,13 +178,6 @@ impl<'a> Iter<'a> {
         r
     }
 
-    pub fn next(&mut self) -> (Verb, Vec<Point>) {
-        let mut points = [Point::default(); Verb::MAX_POINTS];
-        let verb =
-            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
-        (verb, points[0..verb.points()].into())
-    }
-
     pub fn conic_weight(&self) -> Option<scalar> {
         #[allow(clippy::map_clone)]
         self.native()
@@ -206,9 +199,11 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (Verb, Vec<Point>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (verb, points) = self.next();
+        let mut points = [Point::default(); Verb::MAX_POINTS];
+        let verb =
+            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
         if verb != Verb::Done {
-            Some((verb, points))
+            Some((verb, points[0..verb.points()].into()))
         } else {
             None
         }

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -124,7 +124,7 @@ impl IRect {
         *self = Self::new_empty()
     }
 
-    #[deprecated(since = "m78", note = "use set_ltrb()")]
+    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -231,7 +231,7 @@ impl IRect {
         unsafe { r.native_mut().intersect(a.native(), b.native()) }.if_true_some(r)
     }
 
-    #[deprecated(since = "m78", note = "removed without alternative")]
+    #[deprecated(since = "0.0.0", note = "removed without alternative")]
     pub fn intersect_no_empty_check(a: &Self, b: &Self) -> Option<Self> {
         Self::intersect_no_empty_check_(a, b)
     }
@@ -240,7 +240,7 @@ impl IRect {
         Self::intersect(a, b).is_some()
     }
 
-    #[deprecated(since = "m78", note = "removed without alternative")]
+    #[deprecated(since = "0.0.0", note = "removed without alternative")]
     pub fn intersects_no_empty_check(a: &Self, b: &Self) -> bool {
         Self::intersect_no_empty_check_(a, b).is_some()
     }
@@ -488,7 +488,7 @@ impl Rect {
         *self = Self::from_irect(irect)
     }
 
-    #[deprecated(since = "m78", note = "use set_ltrb()")]
+    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -497,12 +497,12 @@ impl Rect {
         *self = Self::new(left, top, right, bottom)
     }
 
-    #[deprecated(since = "m78", note = "use from_irect()")]
+    #[deprecated(since = "0.0.0", note = "use from_irect()")]
     pub fn iset(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         *self = Self::from_irect(IRect::new(left, top, right, bottom))
     }
 
-    #[deprecated(since = "m78", note = "use from_isize()")]
+    #[deprecated(since = "0.0.0", note = "use from_isize()")]
     pub fn iset_wh(&mut self, width: i32, height: i32) {
         *self = Self::from_isize(ISize::new(width, height))
     }
@@ -612,7 +612,7 @@ impl Rect {
         unsafe { self.native_mut().intersect(r.as_ref().native()) }
     }
 
-    #[deprecated(since = "m78", note = "use intersect()")]
+    #[deprecated(since = "0.0.0", note = "use intersect()")]
     pub fn intersect_ltrb(
         &mut self,
         left: scalar,
@@ -631,7 +631,7 @@ impl Rect {
         }
     }
 
-    #[deprecated(since = "m78", note = "use intersects()")]
+    #[deprecated(since = "0.0.0", note = "use intersects()")]
     pub fn intersects_ltrb(
         &self,
         left: scalar,
@@ -687,7 +687,7 @@ impl Rect {
         l < r && t < b
     }
 
-    #[deprecated(since = "m78", note = "use join()")]
+    #[deprecated(since = "0.0.0", note = "use join()")]
     pub fn join_ltrb(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.join(Rect::new(left, top, right, bottom))
     }

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -141,7 +141,7 @@ impl IRect {
         self.left = 0;
         self.top = 0;
         self.right = width;
-        self.bottom = width;
+        self.bottom = height;
     }
 
     #[must_use]

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -102,7 +102,7 @@ impl Handle<SkRegion> {
         unsafe { self.native_mut().setRect(rect.as_ref().native()) }
     }
 
-    #[deprecated(since = "m78", note = "use set_rect()")]
+    #[deprecated(since = "0.0.0", note = "use set_rect()")]
     pub fn set_rect_ltbr(&mut self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         self.set_rect(IRect::new(left, top, right, bottom))
     }
@@ -151,7 +151,7 @@ impl Handle<SkRegion> {
         unsafe { sb::C_SkRegion_quickContains(self.native(), r.native()) }
     }
 
-    #[deprecated(since = "m78", note = "use quick_contains()")]
+    #[deprecated(since = "0.0.0", note = "use quick_contains()")]
     pub fn quick_contains_ltrb(&self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         let rect = IRect::new(left, top, right, bottom);
         self.quick_contains(rect)

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -102,6 +102,7 @@ impl Handle<SkRegion> {
         unsafe { self.native_mut().setRect(rect.as_ref().native()) }
     }
 
+    #[deprecated(since = "m78", note = "use set_rect()")]
     pub fn set_rect_ltbr(&mut self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         self.set_rect(IRect::new(left, top, right, bottom))
     }
@@ -147,11 +148,13 @@ impl Handle<SkRegion> {
 
     pub fn quick_contains(&self, r: impl AsRef<IRect>) -> bool {
         let r = r.as_ref();
-        self.quick_contains_ltrb(r.left, r.top, r.right, r.bottom)
+        unsafe { sb::C_SkRegion_quickContains(self.native(), r.native()) }
     }
 
+    #[deprecated(since = "m78", note = "use quick_contains()")]
     pub fn quick_contains_ltrb(&self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
-        unsafe { sb::C_SkRegion_quickContains(self.native(), left, top, right, bottom) }
+        let rect = IRect::new(left, top, right, bottom);
+        self.quick_contains(rect)
     }
 
     // see also the quick_reject() trait below.

--- a/skia-safe/src/core/size.rs
+++ b/skia-safe/src/core/size.rs
@@ -25,7 +25,7 @@ impl ISize {
         }
     }
 
-    pub fn new_empty() -> ISize {
+    pub const fn new_empty() -> ISize {
         Self::new(0, 0)
     }
 

--- a/skia-safe/src/core/yuva_index.rs
+++ b/skia-safe/src/core/yuva_index.rs
@@ -1,21 +1,7 @@
 use crate::prelude::*;
+use crate::ColorChannel;
 use skia_bindings as sb;
-use skia_bindings::{SkColorChannel, SkYUVAIndex, SkYUVAIndex_Index};
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(i32)]
-pub enum ColorChannel {
-    R = SkColorChannel::kR as _,
-    G = SkColorChannel::kG as _,
-    B = SkColorChannel::kB as _,
-    A = SkColorChannel::kA as _,
-}
-
-impl NativeTransmutable<SkColorChannel> for ColorChannel {}
-#[test]
-fn test_color_channel_layout() {
-    ColorChannel::test_layout()
-}
+use skia_bindings::{SkYUVAIndex, SkYUVAIndex_Index};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -21,6 +21,7 @@ pub mod drop_shadow_image_filter;
 pub mod gradient_shader;
 pub mod high_contrast_filter;
 pub use high_contrast_filter::{high_contrast_config, HighContrastConfig};
+pub mod image_filters;
 pub mod image_source;
 pub mod layer_draw_looper;
 pub mod lighting_image_filter;

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -1,17 +1,17 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter, Region};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter, Region};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn alpha_threshold<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         region: &Region,
         inner_min: scalar,
         outer_max: scalar,
     ) -> Option<Self> {
-        new(region, inner_min, outer_max, self, crop_rect)
+        image_filters::alpha_threshold(region, inner_min, outer_max, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -15,6 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::alpha_threshold()")]
 pub fn new<'a>(
     region: &Region,
     inner_min: scalar,

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::alpha_threshold()")]
+#[deprecated(since = "0.0.0", note = "use image_filters::alpha_threshold()")]
 pub fn new<'a>(
     region: &Region,
     inner_min: scalar,

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter, ImageFilter};
+use crate::{image_filter, image_filters, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
@@ -9,9 +9,19 @@ impl RCHandle<SkImageFilter> {
         inputs: impl Into<ArithmeticFPInputs>,
         background: Self,
         foreground: Self,
-        crop_rect: impl Into<Option<&'a image_filter::CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(inputs, background, foreground, crop_rect)
+        let inputs = inputs.into();
+        image_filters::arithmetic(
+            inputs.k[0],
+            inputs.k[1],
+            inputs.k[2],
+            inputs.k[3],
+            inputs.enforce_pm_color,
+            background,
+            foreground,
+            crop_rect,
+        )
     }
 }
 

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -41,7 +41,7 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[deprecated(since = "m78", note = "use image_filters::arithmetic()")]
+#[deprecated(since = "0.0.0", note = "use image_filters::arithmetic()")]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
     background: ImageFilter,

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -31,6 +31,7 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[deprecated(since = "m78", note = "use image_filters::arithmetic()")]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
     background: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -16,6 +16,7 @@ impl RCHandle<SkImageFilter> {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 pub enum TileMode {
     Clamp = SkBlurImageFilter_TileMode::kClamp_TileMode as _,
     Repeat = SkBlurImageFilter_TileMode::kRepeat_TileMode as _,
@@ -28,6 +29,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     input: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -32,7 +32,7 @@ fn test_tile_mode_layout() {
 }
 
 #[allow(deprecated)]
-#[deprecated(since = "m78", note = "use image_filters::blur")]
+#[deprecated(since = "0.0.0", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     input: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -1,34 +1,37 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkBlurImageFilter_TileMode, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn blur<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         sigma: (scalar, scalar),
-        tile_mode: impl Into<Option<TileMode>>,
+        tile_mode: impl Into<Option<crate::TileMode>>,
     ) -> Option<Self> {
-        new(sigma, self, crop_rect, tile_mode)
+        image_filters::blur(sigma, tile_mode, self, crop_rect)
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 pub enum TileMode {
     Clamp = SkBlurImageFilter_TileMode::kClamp_TileMode as _,
     Repeat = SkBlurImageFilter_TileMode::kRepeat_TileMode as _,
     ClampToBlack = SkBlurImageFilter_TileMode::kClampToBlack_TileMode as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkBlurImageFilter_TileMode> for TileMode {}
+#[allow(deprecated)]
 #[test]
 fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[allow(deprecated)]
 #[deprecated(since = "m78", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -1,15 +1,15 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ColorFilter, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, ColorFilter, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn color_filter<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         cf: ColorFilter,
     ) -> Option<Self> {
-        new(cf, self, crop_rect)
+        image_filters::color_filter(cf, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::color_filter")]
 pub fn new<'a>(
     cf: ColorFilter,
     input: ImageFilter,

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::color_filter")]
+#[deprecated(since = "0.0.0", note = "use image_filters::color_filter")]
 pub fn new<'a>(
     cf: ColorFilter,
     input: ImageFilter,

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -9,6 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::compose")]
 pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::compose")]
+#[deprecated(since = "0.0.0", note = "use image_filters::compose")]
 pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::ImageFilter;
+use crate::{image_filters, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<Self> {
-        new(outer, inner)
+        image_filters::compose(outer, inner)
     }
 }
 

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::ColorChannel")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::ColorChannel")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ChannelSelector {
@@ -34,7 +34,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
-#[deprecated(since = "m78", note = "use color_filters::displacement_map")]
+#[deprecated(since = "0.0.0", note = "use color_filters::displacement_map")]
 #[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -15,6 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::ColorChannel")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ChannelSelector {
@@ -31,6 +32,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use color_filters::displacement_map")]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),
     scale: scalar,

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -1,17 +1,17 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, ColorChannel, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkDisplacementMapEffect_ChannelSelectorType, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn displacement_map_effect<'a>(
-        channel_selectors: (ChannelSelector, ChannelSelector),
+        channel_selectors: (ColorChannel, ColorChannel),
         scale: scalar,
         displacement: ImageFilter,
         color: ImageFilter,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(channel_selectors, scale, displacement, color, crop_rect)
+        image_filters::displacement_map(channel_selectors, scale, displacement, color, crop_rect)
     }
 }
 
@@ -26,13 +26,16 @@ pub enum ChannelSelector {
     A = SkDisplacementMapEffect_ChannelSelectorType::kA_ChannelSelectorType as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkDisplacementMapEffect_ChannelSelectorType> for ChannelSelector {}
 #[test]
+#[allow(deprecated)]
 fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
 #[deprecated(since = "m78", note = "use color_filters::displacement_map")]
+#[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),
     scale: scalar,

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -30,6 +30,10 @@ fn test_shadow_mode_layout() {
     ShadowMode::test_layout();
 }
 
+#[deprecated(
+    since = "m78",
+    note = "use color_filters::drop_shadow & color_filters::drop_shadow_only"
+)]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -38,7 +38,7 @@ fn test_shadow_mode_layout() {
 }
 
 #[deprecated(
-    since = "m78",
+    since = "0.0.0",
     note = "use color_filters::drop_shadow & color_filters::drop_shadow_only"
 )]
 pub fn new<'a>(

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -1,18 +1,25 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, Color, ImageFilter, Vector};
+use crate::{image_filter::CropRect, image_filters, scalar, Color, IRect, ImageFilter, Vector};
 use skia_bindings as sb;
 use skia_bindings::{SkDropShadowImageFilter_ShadowMode, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn drop_shadow<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         delta: impl Into<Vector>,
         sigma: (scalar, scalar),
         color: impl Into<Color>,
         shadow_mode: ShadowMode,
     ) -> Option<Self> {
-        new(delta, sigma, color, shadow_mode, self, crop_rect)
+        match shadow_mode {
+            ShadowMode::DrawShadowAndForeground => {
+                image_filters::drop_shadow(delta, sigma, color, self, crop_rect)
+            }
+            ShadowMode::DrawShadowOnly => {
+                image_filters::drop_shadow_only(delta, sigma, color, self, crop_rect)
+            }
+        }
     }
 }
 

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -1,0 +1,482 @@
+use crate::prelude::*;
+use crate::{
+    scalar, BlendMode, Color, ColorChannel, ColorFilter, FilterQuality, IPoint, IRect, ISize,
+    Image, ImageFilter, Matrix, Paint, Picture, Point3, Rect, Region, TileMode, Vector,
+};
+use skia_bindings as sb;
+use skia_bindings::SkImageFilter;
+
+pub fn alpha_threshold<'a>(
+    region: &Region,
+    inner_min: scalar,
+    outer_max: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_AlphaThreshold(
+            region.native(),
+            inner_min,
+            outer_max,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn arithmetic<'a>(
+    k1: scalar,
+    k2: scalar,
+    k3: scalar,
+    k4: scalar,
+    enforce_pm_color: bool,
+    background: ImageFilter,
+    foreground: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Arithmetic(
+            k1,
+            k2,
+            k3,
+            k4,
+            enforce_pm_color,
+            background.into_ptr(),
+            foreground.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn blur<'a>(
+    (sigma_x, sigma_y): (scalar, scalar),
+    tile_mode: impl Into<Option<TileMode>>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Blur(
+            sigma_x,
+            sigma_y,
+            tile_mode.into().unwrap_or(TileMode::Decal).into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn color_filter<'a>(
+    cf: ColorFilter,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_ColorFilter(
+            cf.into_ptr(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Compose(outer.into_ptr(), inner.into_ptr())
+    })
+}
+
+pub fn displacement_map<'a>(
+    (x_channel_selector, y_channel_selector): (ColorChannel, ColorChannel),
+    scale: scalar,
+    displacement: ImageFilter,
+    color: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DisplacementMap(
+            x_channel_selector.into_native(),
+            y_channel_selector.into_native(),
+            scale,
+            displacement.into_ptr(),
+            color.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn drop_shadow<'a>(
+    delta: impl Into<Vector>,
+    (sigma_x, sigma_y): (scalar, scalar),
+    color: impl Into<Color>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    let color = color.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DropShadow(
+            delta.x,
+            delta.y,
+            sigma_x,
+            sigma_y,
+            color.into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn drop_shadow_only<'a>(
+    delta: impl Into<Vector>,
+    (sigma_x, sigma_y): (scalar, scalar),
+    color: impl Into<Color>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    let color = color.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DropShadowOnly(
+            delta.x,
+            delta.y,
+            sigma_x,
+            sigma_y,
+            color.into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn image<'a>(
+    image: Image,
+    src_rect: impl Into<Option<&'a Rect>>,
+    dst_rect: impl Into<Option<&'a Rect>>,
+    filter_quality: impl Into<Option<FilterQuality>>,
+) -> Option<ImageFilter> {
+    let image_rect = Rect::from_iwh(image.width(), image.height());
+    let src_rect = src_rect.into().unwrap_or(&image_rect);
+    let dst_rect = dst_rect.into().unwrap_or(&image_rect);
+    let filter_quality = filter_quality.into().unwrap_or(FilterQuality::High);
+
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Image(
+            image.into_ptr(),
+            src_rect.as_ref().native(),
+            dst_rect.as_ref().native(),
+            filter_quality.into_native(),
+        )
+    })
+}
+
+pub fn magnifier<'a>(
+    src_rect: impl AsRef<Rect>,
+    inset: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Magnifier(
+            src_rect.as_ref().native(),
+            inset,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn matrix_convolution<'a>(
+    kernel_size: impl Into<ISize>,
+    kernel: &[scalar],
+    gain: scalar,
+    bias: scalar,
+    kernel_offset: impl Into<IPoint>,
+    tile_mode: TileMode,
+    convolve_alpha: bool,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let kernel_size = kernel_size.into();
+    assert_eq!(
+        (kernel_size.width * kernel_size.height) as usize,
+        kernel.len()
+    );
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_MatrixConvolution(
+            kernel_size.native(),
+            kernel.as_ptr(),
+            gain,
+            bias,
+            kernel_offset.into().native(),
+            tile_mode.into_native(),
+            convolve_alpha,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn matrix_transform(
+    matrix: &Matrix,
+    filter_quality: FilterQuality,
+    input: ImageFilter,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_MatrixTransform(
+            matrix.native(),
+            filter_quality.into_native(),
+            input.into_ptr(),
+        )
+    })
+}
+
+#[allow(clippy::new_ret_no_self)]
+pub fn merge<'a>(
+    filters: impl IntoIterator<Item = ImageFilter>,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let filter_ptrs: Vec<*mut SkImageFilter> = filters.into_iter().map(|f| f.into_ptr()).collect();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Merge(
+            filter_ptrs.as_ptr(),
+            filter_ptrs.len().try_into().unwrap(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn offset<'a>(
+    delta: impl Into<Vector>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Offset(
+            delta.x,
+            delta.y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn paint<'a>(paint: &Paint, crop_rect: impl Into<Option<&'a IRect>>) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Paint(paint.native(), crop_rect.into().native_ptr_or_null())
+    })
+}
+
+pub fn picture<'a>(
+    picture: Picture,
+    target_rect: impl Into<Option<&'a Rect>>,
+) -> Option<ImageFilter> {
+    let picture_rect = picture.cull_rect();
+    let target_rect = target_rect.into().unwrap_or(&picture_rect);
+
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Picture(picture.into_ptr(), target_rect.native())
+    })
+}
+
+pub fn tile(
+    src: impl AsRef<Rect>,
+    dst: impl AsRef<Rect>,
+    input: ImageFilter,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Tile(
+            src.as_ref().native(),
+            dst.as_ref().native(),
+            input.into_ptr(),
+        )
+    })
+}
+
+pub fn xfermode<'a>(
+    blend_mode: BlendMode,
+    background: ImageFilter,
+    foreground: impl Into<Option<ImageFilter>>,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Xfermode(
+            blend_mode.into_native(),
+            background.into_ptr(),
+            foreground.into().into_ptr_or_null(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn dilate<'a>(
+    (radius_x, radius_y): (i32, i32),
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Dilate(
+            radius_x,
+            radius_y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn erode<'a>(
+    (radius_x, radius_y): (i32, i32),
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Erode(
+            radius_x,
+            radius_y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn distant_lit_diffuse<'a>(
+    direction: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DistantLitDiffuse(
+            direction.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn point_lit_diffuse<'a>(
+    location: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_PointLitDiffuse(
+            location.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spot_lit_diffuse<'a>(
+    location: impl Into<Point3>,
+    target: impl Into<Point3>,
+    specular_exponent: scalar,
+    cutoff_angle: scalar,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_SpotLitDiffuse(
+            location.into().native(),
+            target.into().native(),
+            specular_exponent,
+            cutoff_angle,
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn distant_lit_specular<'a>(
+    direction: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_ImageFilters_DistantLitSpecular(
+            direction.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn point_lit_specular<'a>(
+    location: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_PointLitSpecular(
+            location.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spot_lit_specular<'a>(
+    location: impl Into<Point3>,
+    target: impl Into<Point3>,
+    specular_exponent: scalar,
+    cutoff_angle: scalar,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_SpotLitSpecular(
+            location.into().native(),
+            target.into().native(),
+            specular_exponent,
+            cutoff_angle,
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,12 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::image")]
+#[deprecated(since = "0.0.0", note = "use color_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::image")]
+#[deprecated(since = "0.0.0", note = "use color_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::{FilterQuality, Image, ImageFilter, Rect};
+use crate::{image_filters, FilterQuality, Image, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::{SkImage, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn from_image(image: Image) -> Option<Self> {
-        from_image(image)
+        image_filters::image(image, None, None, None)
     }
 
     pub fn from_image_rect(
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
     ) -> Option<Self> {
-        from_image_rect(image, src_rect, dst_rect, filter_quality)
+        image_filters::image(image, src_rect.as_ref(), dst_rect.as_ref(), filter_quality)
     }
 }
 
@@ -24,7 +24,7 @@ impl RCHandle<SkImage> {
     }
 
     pub fn into_filter(self) -> Option<ImageFilter> {
-        from_image(self)
+        image_filters::image(self, None, None, None)
     }
 
     pub fn as_filter_rect(
@@ -43,7 +43,7 @@ impl RCHandle<SkImage> {
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
     ) -> Option<ImageFilter> {
-        from_image_rect(self, src_rect, dst_rect, filter_quality)
+        image_filters::image(self, src_rect.as_ref(), dst_rect.as_ref(), filter_quality)
     }
 }
 

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,10 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -126,7 +126,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::distant_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -147,7 +147,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::point_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -168,7 +168,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::spot_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -196,7 +196,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::distant_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -219,7 +219,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::point_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -242,7 +242,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::spot_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -119,6 +119,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -139,6 +140,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -159,6 +161,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -186,6 +189,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -208,6 +212,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -230,6 +235,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -1,35 +1,42 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, Color, ImageFilter, Point3};
+use crate::{image_filter::CropRect, image_filters, scalar, Color, IRect, ImageFilter, Point3};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn distant_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        distant_lit_diffuse(direction, light_color, surface_scale, kd, self, crop_rect)
+        image_filters::distant_lit_diffuse(
+            direction,
+            light_color,
+            surface_scale,
+            kd,
+            self,
+            crop_rect,
+        )
     }
 
     pub fn point_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        point_lit_diffuse(location, light_color, surface_scale, kd, self, crop_rect)
+        image_filters::point_lit_diffuse(location, light_color, surface_scale, kd, self, crop_rect)
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
         specular_exponent: scalar,
@@ -38,7 +45,7 @@ impl RCHandle<SkImageFilter> {
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        spot_lit_diffuse(
+        image_filters::spot_lit_diffuse(
             location,
             target,
             specular_exponent,
@@ -53,14 +60,14 @@ impl RCHandle<SkImageFilter> {
 
     pub fn distant_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        distant_lit_specular(
+        image_filters::distant_lit_specular(
             direction,
             light_color,
             surface_scale,
@@ -73,14 +80,14 @@ impl RCHandle<SkImageFilter> {
 
     pub fn point_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        point_lit_specular(
+        image_filters::point_lit_specular(
             location,
             light_color,
             surface_scale,
@@ -94,7 +101,7 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
         specular_exponent: scalar,
@@ -104,7 +111,7 @@ impl RCHandle<SkImageFilter> {
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        spot_lit_specular(
+        image_filters::spot_lit_specular(
             location,
             target,
             specular_exponent,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::magnifier")]
+#[deprecated(since = "0.0.0", note = "use color_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,6 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -1,16 +1,16 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter, Rect};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn magnifier<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         src_rect: impl AsRef<Rect>,
         inset: scalar,
     ) -> Option<Self> {
-        new(src_rect, inset, self, crop_rect)
+        image_filters::magnifier(src_rect, inset, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, IPoint, ISize, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, IPoint, IRect, ISize, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkMatrixConvolutionImageFilter_TileMode};
 
@@ -7,16 +7,16 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn matrix_convolution<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         kernel_size: impl Into<ISize>,
         kernel: &[scalar],
         gain: scalar,
         bias: scalar,
         kernel_offset: impl Into<IPoint>,
-        tile_mode: TileMode,
+        tile_mode: crate::TileMode,
         convolve_alpha: bool,
     ) -> Option<Self> {
-        new(
+        image_filters::matrix_convolution(
             kernel_size,
             kernel,
             gain,
@@ -39,6 +39,7 @@ pub enum TileMode {
     ClampToBlack = SkMatrixConvolutionImageFilter_TileMode::kClampToBlack_TileMode as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkMatrixConvolutionImageFilter_TileMode> for TileMode {}
 #[test]
 fn test_tile_mode_layout() {
@@ -46,6 +47,7 @@ fn test_tile_mode_layout() {
 }
 
 #[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
+#[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(
     kernel_size: impl Into<ISize>,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -42,6 +42,7 @@ pub enum TileMode {
 #[allow(deprecated)]
 impl NativeTransmutable<SkMatrixConvolutionImageFilter_TileMode> for TileMode {}
 #[test]
+#[allow(deprecated)]
 fn test_tile_mode_layout() {
     TileMode::test_layout();
 }

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -30,6 +30,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -44,6 +45,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(
     kernel_size: impl Into<ISize>,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -30,7 +30,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -46,7 +46,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
-#[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
+#[deprecated(since = "0.0.0", note = "use color_filters::matrix_convolution")]
 #[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::merge")]
+#[deprecated(since = "0.0.0", note = "use color_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 use std::convert::TryInto;
@@ -7,9 +7,9 @@ use std::convert::TryInto;
 impl RCHandle<SkImageFilter> {
     pub fn merge<'a>(
         filters: impl IntoIterator<Item = Self>,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(filters, crop_rect)
+        image_filters::merge(filters, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,7 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "m78", note = "use color_filters::dilate")]
+    #[deprecated(since = "0.0.0", note = "use color_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -49,7 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "m78", note = "use color_filters::erode")]
+    #[deprecated(since = "0.0.0", note = "use color_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -1,22 +1,22 @@
-use crate::image_filter::CropRect;
 use crate::prelude::*;
+use crate::{image_filters, IRect};
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn dilate<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
-        dilate_image_filter::new(radii, self, crop_rect)
+        image_filters::dilate(radii, self, crop_rect)
     }
 
     pub fn erode<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
-        erode_image_filter::new(radii, self, crop_rect)
+        image_filters::erode(radii, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,6 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
+    #[deprecated(since = "m78", note = "use color_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -48,6 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
+    #[deprecated(since = "m78", note = "use color_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -1,15 +1,15 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter, Vector};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter, Vector};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn offset<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         delta: impl Into<Vector>,
     ) -> Option<Self> {
-        new(delta, self, crop_rect)
+        image_filters::offset(delta, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::offset")]
+#[deprecated(since = "0.0.0", note = "use color_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -18,7 +18,7 @@ impl Handle<SkPaint> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::paint")]
+#[deprecated(since = "0.0.0", note = "use color_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -1,23 +1,20 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter, Paint};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter, Paint};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkPaint};
 
 impl RCHandle<SkImageFilter> {
-    pub fn from_paint<'a>(
-        paint: &Paint,
-        crop_rect: impl Into<Option<&'a CropRect>>,
-    ) -> Option<Self> {
-        from_paint(paint, crop_rect)
+    pub fn from_paint<'a>(paint: &Paint, crop_rect: impl Into<Option<&'a IRect>>) -> Option<Self> {
+        image_filters::paint(paint, crop_rect)
     }
 }
 
 impl Handle<SkPaint> {
     pub fn as_image_filter<'a>(
         &self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<ImageFilter> {
-        from_paint(self, crop_rect)
+        image_filters::paint(self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -21,6 +21,7 @@ impl Handle<SkPaint> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,7 +28,7 @@ impl RCHandle<SkPicture> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::picture")]
+#[deprecated(since = "0.0.0", note = "use color_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
     target_rect: impl Into<Option<&'a Rect>>,

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,11 +28,12 @@ impl RCHandle<SkPicture> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
-    crop_rect: impl Into<Option<&'a Rect>>,
+    target_rect: impl Into<Option<&'a Rect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
-        sb::C_SkPictureImageFilter_Make(picture.into_ptr(), crop_rect.into().native_ptr_or_null())
+        sb::C_SkPictureImageFilter_Make(picture.into_ptr(), target_rect.into().native_ptr_or_null())
     })
 }

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{ImageFilter, Picture, Rect};
+use crate::{image_filters, ImageFilter, Picture, Rect};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkPicture};
 
@@ -8,7 +8,7 @@ impl RCHandle<SkImageFilter> {
         picture: Picture,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<Self> {
-        from_picture(picture, crop_rect)
+        image_filters::picture(picture, crop_rect)
     }
 }
 
@@ -24,7 +24,7 @@ impl RCHandle<SkPicture> {
         self,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<ImageFilter> {
-        from_picture(self, crop_rect)
+        image_filters::picture(self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::tile")]
+#[deprecated(since = "0.0.0", note = "use color_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,6 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::{ImageFilter, Rect};
+use crate::{image_filters, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn tile(self, src: impl AsRef<Rect>, dst: impl AsRef<Rect>) -> Option<Self> {
-        new(src, dst, self)
+        image_filters::tile(src, dst, self)
     }
 }
 

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,6 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::xfermode")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, BlendMode, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, BlendMode, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
@@ -8,13 +8,13 @@ impl RCHandle<SkImageFilter> {
         blend_mode: BlendMode,
         background: ImageFilter,
         foreground: impl Into<Option<ImageFilter>>,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(blend_mode, background, foreground, crop_rect)
+        image_filters::xfermode(blend_mode, background, foreground, crop_rect)
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::xfermode")]
+#[deprecated(since = "m78", note = "use color_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::xfermode()")]
+#[deprecated(since = "0.0.0", note = "use color_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -47,6 +47,7 @@ impl Handle<GrBackendFormat> {
         })
     }
 
+    #[deprecated(since = "0.0.0", note = "use backend()")]
     pub fn backend_api(&self) -> BackendAPI {
         BackendAPI::from_native(self.native().fBackend)
     }

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -49,38 +49,37 @@ impl Handle<GrBackendFormat> {
 
     #[deprecated(since = "0.0.0", note = "use backend()")]
     pub fn backend_api(&self) -> BackendAPI {
+        self.backend()
+    }
+
+    pub fn backend(&self) -> BackendAPI {
         BackendAPI::from_native(self.native().fBackend)
     }
 
+    // texture_type() would return a private type.
+
+    #[deprecated(since = "0.0.0", note = "use as_gl_format()")]
     pub fn gl_format(&self) -> Option<gl::Enum> {
-        unsafe {
-            #[allow(clippy::map_clone)]
-            self.native()
-                .getGLFormat()
-                .into_option()
-                .map(|format| *format)
-        }
+        Some(self.as_gl_format() as _)
     }
 
-    pub fn gl_target(&self) -> Option<gl::Enum> {
-        unsafe {
+    pub fn as_gl_format(&self) -> gl::Format {
+        gl::Format::from_native(unsafe {
             #[allow(clippy::map_clone)]
-            self.native()
-                .getGLTarget()
-                .into_option()
-                .map(|target| *target)
-        }
+            self.native().asGLFormat()
+        })
+    }
+
+    #[deprecated(since = "0.0.0", note = "use as_vk_format()")]
+    #[cfg(feature = "vulkan")]
+    pub fn vulkan_format(&self) -> Option<vk::Format> {
+        self.as_vk_format()
     }
 
     #[cfg(feature = "vulkan")]
-    pub fn vulkan_format(&self) -> Option<vk::Format> {
-        unsafe {
-            #[allow(clippy::map_clone)]
-            self.native()
-                .getVkFormat()
-                .into_option()
-                .map(|format| *format)
-        }
+    pub fn as_vk_format(&self) -> Option<vk::Format> {
+        let mut r = vk::Format::UNDEFINED;
+        unsafe { self.native().asVkFormat(&mut r) }.if_true_some(r)
     }
 
     pub fn to_texture_2d(&self) -> Option<Self> {

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -224,13 +224,16 @@ impl RCHandle<GrContext> {
     }
 
     pub fn default_backend_format(&self, ct: ColorType, renderable: Renderable) -> BackendFormat {
-        BackendFormat::from_native(unsafe {
+        let mut format = BackendFormat::default();
+        unsafe {
             sb::C_GrContext_defaultBackendFormat(
                 self.native(),
                 ct.into_native(),
                 renderable.into_native(),
+                format.native_mut(),
             )
-        })
+        };
+        format
     }
 
     // TODO: support createBackendTexture (several variants) and deleteBackendTexture(),

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -1,6 +1,57 @@
 use crate::prelude::NativeTransmutable;
 use skia_bindings as sb;
-use skia_bindings::{GrGLFramebufferInfo, GrGLTextureInfo, GrGLenum, GrGLuint};
+use skia_bindings::{
+    GrGLFormat, GrGLFramebufferInfo, GrGLStandard, GrGLTextureInfo, GrGLenum, GrGLuint,
+};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum Standard {
+    None = GrGLStandard::kNone_GrGLStandard as _,
+    GL = GrGLStandard::kGL_GrGLStandard as _,
+    GLES = GrGLStandard::kGLES_GrGLStandard as _,
+    WebGL = GrGLStandard::kWebGL_GrGLStandard as _,
+}
+
+impl NativeTransmutable<GrGLStandard> for Standard {}
+#[test]
+fn test_standard_layout() {
+    Standard::test_layout()
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+#[allow(non_camel_case_types)]
+pub enum Format {
+    Unknown = GrGLFormat::kUnknown as _,
+    RGBA8 = GrGLFormat::kRGBA8 as _,
+    R8 = GrGLFormat::kR8 as _,
+    ALPHA8 = GrGLFormat::kALPHA8 as _,
+    LUMINANCE8 = GrGLFormat::kLUMINANCE8 as _,
+    BGRA8 = GrGLFormat::kBGRA8 as _,
+    RGB565 = GrGLFormat::kRGB565 as _,
+    RGBA16F = GrGLFormat::kRGBA16F as _,
+    R16F = GrGLFormat::kR16F as _,
+    RGB8 = GrGLFormat::kRGB8 as _,
+    RG8 = GrGLFormat::kRG8 as _,
+    RGB10_A2 = GrGLFormat::kRGB10_A2 as _,
+    RGBA4 = GrGLFormat::kRGBA4 as _,
+    RGBA32F = GrGLFormat::kRGBA32F as _,
+    SRGB8_ALPHA8 = GrGLFormat::kSRGB8_ALPHA8 as _,
+    COMPRESSED_RGB8_ETC2 = GrGLFormat::kCOMPRESSED_RGB8_ETC2 as _,
+    COMPRESSED_ETC1_RGB8 = GrGLFormat::kCOMPRESSED_ETC1_RGB8 as _,
+    R16 = GrGLFormat::kR16 as _,
+    RG16 = GrGLFormat::kRG16 as _,
+    RGBA16 = GrGLFormat::kRGBA16 as _,
+    RG16F = GrGLFormat::kRG16F as _,
+    LUMINANCE16F = GrGLFormat::kLUMINANCE16F as _,
+}
+
+impl NativeTransmutable<GrGLFormat> for Format {}
+#[test]
+fn test_format_layout() {
+    Format::test_layout()
+}
 
 pub type Enum = GrGLenum;
 pub type UInt = GrGLuint;

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -36,7 +36,6 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
-pub use sb::VkStructureType as StructureType;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;
 

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -36,6 +36,7 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
+pub use sb::VkStructureType as StructureType;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;
 

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -110,6 +110,7 @@ impl Default for YcbcrConversionInfo {
 }
 
 impl YcbcrConversionInfo {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_format(
         format: vk::Format,
         external_format: u64,

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -3,8 +3,7 @@ use crate::gpu::Protected;
 use crate::prelude::*;
 use skia_bindings as sb;
 use skia_bindings::{
-    GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkDrawableInfo, GrVkImageInfo,
-    GrVkYcbcrConversionInfo,
+    GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkImageInfo, GrVkYcbcrConversionInfo,
 };
 use std::ffi::CStr;
 use std::os::raw;

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -3,7 +3,8 @@ use crate::gpu::Protected;
 use crate::prelude::*;
 use skia_bindings as sb;
 use skia_bindings::{
-    GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkImageInfo, GrVkYcbcrConversionInfo,
+    GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkDrawableInfo, GrVkImageInfo,
+    GrVkYcbcrConversionInfo,
 };
 use std::ffi::CStr;
 use std::os::raw;

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "paragraph")]
+#[cfg(feature = "textlayout")]
 pub(crate) mod paragraph;
 #[cfg(feature = "shaper")]
 pub mod shaper;
@@ -6,7 +6,7 @@ pub mod shaper;
 pub use shaper::{icu, Shaper};
 
 // Export everything below paragraph under textlayout
-#[cfg(feature = "paragraph")]
+#[cfg(feature = "textlayout")]
 pub mod textlayout {
     use crate::paragraph;
     pub use paragraph::*;

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,4 +1,13 @@
+#[cfg(feature = "paragraph")]
+pub(crate) mod paragraph;
 #[cfg(feature = "shaper")]
 pub mod shaper;
 #[cfg(feature = "shaper")]
 pub use shaper::{icu, Shaper};
+
+// Export everything below paragraph under textlayout
+#[cfg(feature = "paragraph")]
+pub mod textlayout {
+    use crate::paragraph;
+    pub use paragraph::*;
+}

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -7,6 +7,7 @@ pub use dart_types::*;
 mod font_collection;
 pub use font_collection::*;
 
+#[allow(clippy::module_inception)]
 mod paragraph;
 pub use paragraph::*;
 

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,4 +1,5 @@
 use crate::interop;
+use crate::interop::AsStr;
 use std::ops::Index;
 
 mod dart_types;
@@ -33,14 +34,12 @@ pub struct FontFamilies<'a>(&'a [skia_bindings::SkString]);
 impl Index<usize> for FontFamilies<'_> {
     type Output = str;
     fn index(&self, index: usize) -> &Self::Output {
-        interop::String::from_native_ref(&self.0[index]).as_str()
+        self.0[index].as_str()
     }
 }
 
 impl FontFamilies<'_> {
     pub fn iter(&self) -> impl Iterator<Item = &str> {
-        self.0
-            .iter()
-            .map(|str| interop::String::from_native_ref(str).as_str())
+        self.0.iter().map(|str| str.as_str())
     }
 }

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,0 +1,20 @@
+mod dart_types;
+pub use dart_types::*;
+
+mod font_collection;
+pub use font_collection::*;
+
+mod paragraph;
+pub use paragraph::*;
+
+mod paragraph_builder;
+pub use paragraph_builder::*;
+
+mod text_shadow;
+pub use text_shadow::*;
+
+mod text_style;
+pub use text_style::*;
+
+mod typeface_font_provider;
+pub use typeface_font_provider::*;

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,3 +1,6 @@
+use crate::interop;
+use std::ops::Index;
+
 mod dart_types;
 pub use dart_types::*;
 
@@ -10,6 +13,9 @@ pub use paragraph::*;
 mod paragraph_builder;
 pub use paragraph_builder::*;
 
+mod paragraph_style;
+pub use paragraph_style::*;
+
 mod text_shadow;
 pub use text_shadow::*;
 
@@ -18,3 +24,23 @@ pub use text_style::*;
 
 mod typeface_font_provider;
 pub use typeface_font_provider::*;
+
+/// Efficient reference type to a C++ vector of font family SkStrings.
+///
+/// Use indexer or .iter() to access the Rust str references.
+pub struct FontFamilies<'a>(&'a [skia_bindings::SkString]);
+
+impl Index<usize> for FontFamilies<'_> {
+    type Output = str;
+    fn index(&self, index: usize) -> &Self::Output {
+        interop::String::from_native_ref(&self.0[index]).as_str()
+    }
+}
+
+impl FontFamilies<'_> {
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0
+            .iter()
+            .map(|str| interop::String::from_native_ref(str).as_str())
+    }
+}

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,4 +1,3 @@
-use crate::interop;
 use crate::interop::AsStr;
 use std::ops::Index;
 

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -14,6 +14,9 @@ pub use paragraph::*;
 mod paragraph_builder;
 pub use paragraph_builder::*;
 
+mod paragraph_cache;
+pub use paragraph_cache::*;
+
 mod paragraph_style;
 pub use paragraph_style::*;
 

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -1,0 +1,27 @@
+use crate::prelude::*;
+use crate::Rect;
+use skia_bindings as sb;
+
+pub type Affinity = sb::skia_textlayout_Affinity;
+pub type RectHeightStyle = sb::skia_textlayout_RectHeightStyle;
+pub type RectWidthStyle = sb::skia_textlayout_RectWidthStyle;
+pub type TextAlign = sb::skia_textlayout_TextAlign;
+pub type TextDirection = sb::skia_textlayout_TextDirection;
+
+pub type PositionWithAffinity = sb::skia_textlayout_PositionWithAffinity;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
+pub struct TextBox {
+    pub rect: Rect,
+    pub direct: TextDirection,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_TextBox> for TextBox {}
+
+#[test]
+fn text_box_layout() {
+    TextBox::test_layout()
+}
+
+pub type TextBaseline = sb::skia_textlayout_TextBaseline;

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -24,4 +24,43 @@ fn text_box_layout() {
     TextBox::test_layout()
 }
 
+pub const EMPTY_INDEX: usize = std::usize::MAX;
+
+pub trait RangeExtensions {
+    fn width(&self) -> usize;
+    fn shift(&mut self, d: usize);
+    fn contains(&self, other: &Self) -> bool;
+    fn intersects(&self, other: &Self) -> bool;
+    fn empty(&self) -> bool;
+}
+
+impl RangeExtensions for Range<usize> {
+    fn width(&self) -> usize {
+        self.end - self.start
+    }
+
+    fn shift(&mut self, d: usize) {
+        self.start += d;
+        self.end += d;
+    }
+
+    fn contains(&self, other: &Self) -> bool {
+        self.start <= other.start && self.end >= other.end
+    }
+
+    fn intersects(&self, other: &Self) -> bool {
+        self.start.max(other.start) <= self.end.min(other.end)
+    }
+
+    fn empty(&self) -> bool {
+        self.start == EMPTY_INDEX && self.end == EMPTY_INDEX
+    }
+}
+
+pub const EMPTY_RANGE: Range<usize> = Range {
+    start: EMPTY_INDEX,
+    end: EMPTY_INDEX,
+};
+
 pub use sb::skia_textlayout_TextBaseline as TextBaseline;
+use std::ops::Range;

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -2,13 +2,13 @@ use crate::prelude::*;
 use crate::Rect;
 use skia_bindings as sb;
 
-pub type Affinity = sb::skia_textlayout_Affinity;
-pub type RectHeightStyle = sb::skia_textlayout_RectHeightStyle;
-pub type RectWidthStyle = sb::skia_textlayout_RectWidthStyle;
-pub type TextAlign = sb::skia_textlayout_TextAlign;
-pub type TextDirection = sb::skia_textlayout_TextDirection;
+pub use sb::skia_textlayout_Affinity as Affinity;
+pub use sb::skia_textlayout_RectHeightStyle as RectHeightStyle;
+pub use sb::skia_textlayout_RectWidthStyle as RectWidthStyle;
+pub use sb::skia_textlayout_TextAlign as TextAlign;
+pub use sb::skia_textlayout_TextDirection as TextDirection;
 
-pub type PositionWithAffinity = sb::skia_textlayout_PositionWithAffinity;
+pub use sb::skia_textlayout_PositionWithAffinity as PositionWithAffinity;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(C)]
@@ -24,4 +24,4 @@ fn text_box_layout() {
     TextBox::test_layout()
 }
 
-pub type TextBaseline = sb::skia_textlayout_TextBaseline;
+pub use sb::skia_textlayout_TextBaseline as TextBaseline;

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -77,20 +77,32 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
         &mut self,
         family_name: impl AsRef<str>,
         font_style: FontStyle,
+        locale: impl AsRef<str>,
     ) -> Option<Typeface> {
         let family_name = ffi::CString::new(family_name.as_ref()).unwrap();
+        let locale = interop::String::from_str(locale);
         Typeface::from_ptr(unsafe {
             sb::C_FontCollection_matchTypeface(
                 self.native_mut(),
                 family_name.as_ptr(),
                 font_style.into_native(),
+                locale.native(),
             )
         })
     }
 
-    pub fn match_default_typeface(&mut self, font_style: FontStyle) -> Option<Typeface> {
+    pub fn match_default_typeface(
+        &mut self,
+        font_style: FontStyle,
+        locale: impl AsRef<str>,
+    ) -> Option<Typeface> {
+        let locale = interop::String::from_str(locale);
         Typeface::from_ptr(unsafe {
-            sb::C_FontCollection_matchDefaultTypeface(self.native_mut(), font_style.into_native())
+            sb::C_FontCollection_matchDefaultTypeface(
+                self.native_mut(),
+                font_style.into_native(),
+                locale.native(),
+            )
         })
     }
 

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{interop, FontMgr, FontStyle, Typeface, Unichar};
 use skia_bindings as sb;
-use skia_bindings::C_FontCollection_matchTypeface;
 use std::ffi;
 
 pub type FontCollection = RCHandle<sb::skia_textlayout_FontCollection>;
@@ -81,7 +80,7 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
     ) -> Option<Typeface> {
         let family_name = ffi::CString::new(family_name.as_ref()).unwrap();
         Typeface::from_ptr(unsafe {
-            C_FontCollection_matchTypeface(
+            sb::C_FontCollection_matchTypeface(
                 self.native_mut(),
                 family_name.as_ptr(),
                 font_style.into_native(),

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -70,7 +70,7 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
     }
 
     pub fn fallback_manager(&self) -> Option<FontMgr> {
-        FontMgr::from_unshared_ptr(self.native().fDefaultFontManager.fPtr)
+        FontMgr::from_ptr(unsafe { sb::C_FontCollection_getFallbackManager(self.native()) })
     }
 
     pub fn match_typeface(
@@ -128,7 +128,7 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
     }
 
     pub fn font_fallback_enabled(&self) -> bool {
-        self.native().fEnableFontFallback
+        unsafe { sb::C_FontCollection_fontFallbackEnabled(self.native()) }
     }
 }
 

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -1,0 +1,160 @@
+use crate::prelude::*;
+use crate::{interop, FontMgr, FontStyle, Typeface, Unichar};
+use skia_bindings as sb;
+use skia_bindings::C_FontCollection_matchTypeface;
+use std::ffi;
+
+pub type FontCollection = RCHandle<sb::skia_textlayout_FontCollection>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_FontCollection {
+    type Base = sb::SkRefCntBase;
+}
+
+impl RCHandle<sb::skia_textlayout_FontCollection> {
+    pub fn new() -> Self {
+        Self::from_ptr(unsafe { sb::C_FontCollection_new() }).unwrap()
+    }
+
+    pub fn font_managers_count(&self) -> usize {
+        unsafe { self.native().getFontManagersCount() }
+    }
+
+    pub fn set_asset_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setAssetFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_dynamic_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setDynamicFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_test_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setTestFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_default_font_manager<'a>(
+        &mut self,
+        font_manager: impl Into<Option<FontMgr>>,
+        default_family_name: impl Into<Option<&'a str>>,
+    ) {
+        let font_manager = font_manager.into();
+        unsafe {
+            match default_family_name.into() {
+                Some(fname) => {
+                    let fname = ffi::CString::new(fname).unwrap();
+                    sb::C_FontCollection_setDefaultFontManager2(
+                        self.native_mut(),
+                        font_manager.into_ptr_or_null(),
+                        fname.as_ptr(),
+                    )
+                }
+                None => sb::C_FontCollection_setDefaultFontManager(
+                    self.native_mut(),
+                    font_manager.into_ptr_or_null(),
+                ),
+            }
+        }
+    }
+
+    pub fn fallback_manager(&self) -> Option<FontMgr> {
+        FontMgr::from_unshared_ptr(self.native().fDefaultFontManager.fPtr)
+    }
+
+    pub fn match_typeface(
+        &mut self,
+        family_name: impl AsRef<str>,
+        font_style: FontStyle,
+    ) -> Option<Typeface> {
+        let family_name = ffi::CString::new(family_name.as_ref()).unwrap();
+        Typeface::from_ptr(unsafe {
+            C_FontCollection_matchTypeface(
+                self.native_mut(),
+                family_name.as_ptr(),
+                font_style.into_native(),
+            )
+        })
+    }
+
+    pub fn match_default_typeface(&mut self, font_style: FontStyle) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe {
+            sb::C_FontCollection_matchDefaultTypeface(self.native_mut(), font_style.into_native())
+        })
+    }
+
+    pub fn default_fallback(
+        &mut self,
+        unicode: Unichar,
+        font_style: FontStyle,
+        locale: impl AsRef<str>,
+    ) -> Option<Typeface> {
+        let locale = interop::String::from_str(locale.as_ref());
+        Typeface::from_ptr(unsafe {
+            sb::C_FontCollection_defaultFallback(
+                self.native_mut(),
+                unicode,
+                font_style.into_native(),
+                locale.native(),
+            )
+        })
+    }
+
+    pub fn disable_font_fallback(&mut self) {
+        unsafe { self.native_mut().disableFontFallback() }
+    }
+
+    pub fn font_fallback_enabled(&self) -> bool {
+        self.native().fEnableFontFallback
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::textlayout::FontCollection;
+    use crate::FontMgr;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn ref_counts() {
+        let mut fc = FontCollection::new();
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 1);
+
+        let fm = FontMgr::new();
+        let fm_base = fm.native().ref_counted_base()._ref_cnt();
+
+        fc.set_default_font_manager(fm.clone(), None);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+
+        let cloned_fc = fc.clone();
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 2);
+        drop(cloned_fc);
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 1);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+
+        {
+            let fmc = fc.fallback_manager().unwrap();
+            assert_eq!(fmc.native().ref_counted_base()._ref_cnt(), fm_base + 2);
+            drop(fmc);
+        }
+
+        fc.set_default_font_manager(None, None);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base);
+        drop(fm);
+        drop(fc);
+    }
+}

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::textlayout::ParagraphCache;
 use crate::{interop, FontMgr, FontStyle, Typeface, Unichar};
 use skia_bindings as sb;
 use std::ffi;
@@ -106,7 +107,7 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
         })
     }
 
-    pub fn default_fallback(
+    pub fn default_fallback_char(
         &mut self,
         unicode: Unichar,
         font_style: FontStyle,
@@ -123,12 +124,28 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
         })
     }
 
+    pub fn default_fallback(&mut self) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe { sb::C_FontCollection_defaultFallback2(self.native_mut()) })
+    }
+
     pub fn disable_font_fallback(&mut self) {
         unsafe { self.native_mut().disableFontFallback() }
     }
 
     pub fn font_fallback_enabled(&self) -> bool {
         unsafe { sb::C_FontCollection_fontFallbackEnabled(self.native()) }
+    }
+
+    pub fn paragraph_cache(&self) -> &ParagraphCache {
+        ParagraphCache::from_native_ref(unsafe {
+            &*sb::C_FontCollection_paragraphCache(self.native_mut_force())
+        })
+    }
+
+    pub fn paragraph_cache_mut(&mut self) -> &mut ParagraphCache {
+        ParagraphCache::from_native_ref_mut(unsafe {
+            &mut *sb::C_FontCollection_paragraphCache(self.native_mut())
+        })
     }
 }
 

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -68,6 +68,12 @@ impl RefHandle<sb::skia_textlayout_Paragraph> {
         })
     }
 
+    pub fn get_rects_for_placeholders(&mut self) -> TextBoxes {
+        TextBoxes::construct(|tb| unsafe {
+            sb::C_Paragraph_GetRectsForPlaceholders(self.native_mut(), tb)
+        })
+    }
+
     pub fn get_glyph_position_at_coordinate(
         &mut self,
         p: impl Into<Point>,

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -1,0 +1,129 @@
+use super::{PositionWithAffinity, RectHeightStyle, RectWidthStyle, TextBox};
+use crate::prelude::*;
+use crate::{scalar, Canvas, Point};
+use skia_bindings as sb;
+use std::ops::{Index, Range};
+
+pub type Paragraph = RefHandle<sb::skia_textlayout_Paragraph>;
+
+impl NativeDrop for sb::skia_textlayout_Paragraph {
+    fn drop(&mut self) {
+        unsafe { sb::C_Paragraph_delete(self) }
+    }
+}
+
+impl RefHandle<sb::skia_textlayout_Paragraph> {
+    pub fn max_width(&self) -> scalar {
+        self.native().fWidth
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn min_intrinsic_width(&self) -> scalar {
+        self.native().fMinIntrinsicWidth
+    }
+
+    pub fn max_intrinsic_width(&self) -> scalar {
+        self.native().fMaxIntrinsicWidth
+    }
+
+    pub fn alphabetic_baseline(&self) -> scalar {
+        self.native().fAlphabeticBaseline
+    }
+
+    pub fn ideographic_baseline(&self) -> scalar {
+        self.native().fIdeographicBaseline
+    }
+
+    pub fn did_exceed_max_lines(&mut self) -> bool {
+        unsafe { sb::C_Paragraph_didExceedMaxLines(self.native_mut()) }
+    }
+
+    pub fn layout(&mut self, width: scalar) {
+        unsafe { sb::C_Paragraph_layout(self.native_mut(), width) }
+    }
+
+    pub fn paint(&mut self, canvas: &mut Canvas, p: impl Into<Point>) {
+        let p = p.into();
+        unsafe { sb::C_Paragraph_paint(self.native_mut(), canvas.native_mut(), p.x, p.y) }
+    }
+
+    pub fn get_rects_for_range(
+        &mut self,
+        range: Range<usize>,
+        rect_height_style: RectHeightStyle,
+        rect_width_style: RectWidthStyle,
+    ) -> TextBoxes {
+        TextBoxes::construct(|tb| unsafe {
+            sb::C_Paragraph_getRectsForRange(
+                self.native_mut(),
+                range.start.try_into().unwrap(),
+                range.end.try_into().unwrap(),
+                rect_height_style,
+                rect_width_style,
+                tb,
+            )
+        })
+    }
+
+    pub fn get_glyph_position_at_coordinate(
+        &mut self,
+        p: impl Into<Point>,
+    ) -> PositionWithAffinity {
+        let p = p.into();
+        let mut r = Default::default();
+        unsafe { sb::C_Paragraph_getGlyphPositionAtCoordinate(self.native_mut(), p.x, p.y, &mut r) }
+        r
+    }
+
+    pub fn get_word_boundary(&mut self, offset: u32) -> Range<usize> {
+        let mut range: [usize; 2] = Default::default();
+        unsafe { sb::C_Paragraph_getWordBoundary(self.native_mut(), offset, range.as_mut_ptr()) }
+        range[0]..range[1]
+    }
+
+    pub fn line_number(&mut self) -> usize {
+        unsafe { sb::C_Paragraph_lineNumber(self.native_mut()) }
+    }
+
+    pub fn mark_dirty(&mut self) {
+        unsafe { sb::C_Paragraph_markDirty(self.native_mut()) }
+    }
+}
+
+pub type TextBoxes = Handle<sb::TextBoxes>;
+
+impl NativeDrop for sb::TextBoxes {
+    fn drop(&mut self) {
+        unsafe { sb::C_TextBoxes_destruct(self) }
+    }
+}
+
+impl Index<usize> for Handle<sb::TextBoxes> {
+    type Output = TextBox;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl AsRef<[TextBox]> for TextBoxes {
+    fn as_ref(&self) -> &[TextBox] {
+        self.as_slice()
+    }
+}
+
+impl Handle<sb::TextBoxes> {
+    pub fn iter(&self) -> impl Iterator<Item = &TextBox> {
+        self.as_slice().iter()
+    }
+
+    pub fn as_slice(&self) -> &[TextBox] {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_TextBoxes_ptr_count(self.native(), &mut count);
+            std::slice::from_raw_parts(ptr as *const TextBox, count)
+        }
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -1,4 +1,4 @@
-use super::{FontCollection, Paragraph, ParagraphStyle, TextStyle};
+use super::{FontCollection, Paragraph, ParagraphStyle, PlaceholderStyle, TextStyle};
 use crate::prelude::*;
 use skia_bindings as sb;
 use std::ffi;
@@ -31,6 +31,13 @@ impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
     pub fn add_text(&mut self, str: impl AsRef<str>) -> &mut Self {
         let cstr = ffi::CString::new(str.as_ref()).unwrap();
         unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+        self
+    }
+
+    pub fn add_placeholder(&mut self, placeholder_style: &PlaceholderStyle) -> &mut Self {
+        unsafe {
+            sb::C_ParagraphBuilder_addPlaceholder(self.native_mut(), placeholder_style.native())
+        }
         self
     }
 

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -1,0 +1,48 @@
+use super::{FontCollection, Paragraph, ParagraphStyle, TextStyle};
+use crate::prelude::*;
+use skia_bindings as sb;
+use std::ffi;
+
+pub type ParagraphBuilder = RefHandle<sb::skia_textlayout_ParagraphBuilder>;
+
+impl NativeDrop for sb::skia_textlayout_ParagraphBuilder {
+    fn drop(&mut self) {
+        unsafe { sb::C_ParagraphBuilder_delete(self) }
+    }
+}
+
+impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
+    pub fn push_style(&mut self, style: &TextStyle) {
+        unsafe { sb::C_ParagraphBuilder_pushStyle(self.native_mut(), style.native()) }
+    }
+
+    pub fn pop(&mut self) {
+        unsafe { sb::C_ParagraphBuilder_pop(self.native_mut()) }
+    }
+
+    pub fn peek_style(&mut self) -> TextStyle {
+        let mut ts = TextStyle::default();
+        unsafe { sb::C_ParagraphBuilder_peekStyle(self.native_mut(), ts.native_mut()) }
+        ts
+    }
+
+    pub fn add_text(&mut self, str: impl AsRef<str>) {
+        let cstr = ffi::CString::new(str.as_ref()).unwrap();
+        unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+    }
+
+    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) {
+        unsafe { sb::C_ParagraphBuilder_setParagraphStyle(self.native_mut(), style.native()) }
+    }
+
+    pub fn build(&mut self) -> Paragraph {
+        Paragraph::from_ptr(unsafe { sb::C_ParagraphBuilder_Build(self.native_mut()) }).unwrap()
+    }
+
+    pub fn new(style: &ParagraphStyle, font_collection: FontCollection) -> Self {
+        Self::from_ptr(unsafe {
+            sb::C_ParagraphBuilder_make(style.native(), font_collection.into_ptr())
+        })
+        .unwrap()
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -12,12 +12,14 @@ impl NativeDrop for sb::skia_textlayout_ParagraphBuilder {
 }
 
 impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
-    pub fn push_style(&mut self, style: &TextStyle) {
+    pub fn push_style(&mut self, style: &TextStyle) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_pushStyle(self.native_mut(), style.native()) }
+        self
     }
 
-    pub fn pop(&mut self) {
+    pub fn pop(&mut self) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_pop(self.native_mut()) }
+        self
     }
 
     pub fn peek_style(&mut self) -> TextStyle {
@@ -26,13 +28,15 @@ impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
         ts
     }
 
-    pub fn add_text(&mut self, str: impl AsRef<str>) {
+    pub fn add_text(&mut self, str: impl AsRef<str>) -> &mut Self {
         let cstr = ffi::CString::new(str.as_ref()).unwrap();
         unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+        self
     }
 
-    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) {
+    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_setParagraphStyle(self.native_mut(), style.native()) }
+        self
     }
 
     pub fn build(&mut self) -> Paragraph {

--- a/skia-safe/src/modules/paragraph/paragraph_cache.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_cache.rs
@@ -1,0 +1,37 @@
+use crate::prelude::*;
+use skia_bindings as sb;
+use skia_bindings::skia_textlayout_ParagraphCache;
+
+pub type ParagraphCache = Handle<skia_textlayout_ParagraphCache>;
+
+impl NativeDrop for skia_textlayout_ParagraphCache {
+    fn drop(&mut self) {
+        unsafe { sb::C_ParagraphCache_destruct(self) }
+    }
+}
+
+impl Handle<skia_textlayout_ParagraphCache> {
+    pub fn new() -> ParagraphCache {
+        ParagraphCache::from_native(unsafe { skia_textlayout_ParagraphCache::new() })
+    }
+
+    pub fn abandon(&mut self) {
+        unsafe { self.native_mut().abandon() }
+    }
+
+    pub fn reset(&mut self) {
+        unsafe { self.native_mut().reset() }
+    }
+
+    pub fn print_statistics(&mut self) {
+        unsafe { self.native_mut().printStatistics() }
+    }
+
+    pub fn turn_on(&mut self, value: bool) {
+        self.native_mut().fCacheIsOn = value
+    }
+
+    pub fn count(&mut self) -> i32 {
+        unsafe { sb::C_ParagraphCache_count(self.native_mut()) }
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -38,40 +38,45 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
         }
     }
 
-    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
-        let families = interop::Strings::from_strs(families);
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) -> &mut Self {
+        let families: Vec<interop::String> = FromStrs::from_strs(families);
         let families = families.native();
         unsafe {
             sb::C_StrutStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len());
         }
+        self
     }
 
     pub fn font_style(&self) -> FontStyle {
         FontStyle::from_native(self.native().fFontStyle)
     }
 
-    pub fn set_font_style(&mut self, font_style: FontStyle) {
-        self.native_mut().fFontStyle = font_style.into_native()
+    pub fn set_font_style(&mut self, font_style: FontStyle) -> &mut Self {
+        self.native_mut().fFontStyle = font_style.into_native();
+        self
     }
 
     pub fn font_size(&self) -> scalar {
         self.native().fFontSize
     }
 
-    pub fn set_font_size(&mut self, font_size: scalar) {
+    pub fn set_font_size(&mut self, font_size: scalar) -> &mut Self {
         self.native_mut().fFontSize = font_size;
+        self
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_leading(&mut self, leading: scalar) {
+    pub fn set_leading(&mut self, leading: scalar) -> &mut Self {
         self.native_mut().fLeading = leading;
+        self
     }
 
     pub fn leading(&self) -> scalar {
@@ -82,16 +87,18 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
         self.native().fStrutEnabled
     }
 
-    pub fn set_strut_enabled(&mut self, strut_enabled: bool) {
+    pub fn set_strut_enabled(&mut self, strut_enabled: bool) -> &mut Self {
         self.native_mut().fStrutEnabled = strut_enabled;
+        self
     }
 
     pub fn force_strut_height(&self) -> bool {
         self.native().fForceStrutHeight
     }
 
-    pub fn set_force_strut_height(&mut self, force_strut_height: bool) {
+    pub fn set_force_strut_height(&mut self, force_strut_height: bool) -> &mut Self {
         self.native_mut().fForceStrutHeight = force_strut_height;
+        self
     }
 }
 
@@ -130,35 +137,39 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         StrutStyle::from_native_ref(&self.native().fStrutStyle)
     }
 
-    pub fn set_strut_style(&mut self, strut_style: StrutStyle) {
+    pub fn set_strut_style(&mut self, strut_style: StrutStyle) -> &mut Self {
         self.native_mut().fStrutStyle.replace_with(strut_style);
+        self
     }
 
     pub fn text_style(&self) -> &TextStyle {
         TextStyle::from_native_ref(&self.native().fDefaultTextStyle)
     }
 
-    pub fn set_text_style(&mut self, text_style: &TextStyle) {
+    pub fn set_text_style(&mut self, text_style: &TextStyle) -> &mut Self {
         // TODO: implement the assignment operator in C.
         self.native_mut()
             .fDefaultTextStyle
             .replace_with(text_style.clone());
+        self
     }
 
     pub fn text_direction(&self) -> TextDirection {
         self.native().fTextDirection
     }
 
-    pub fn set_text_direction(&mut self, direction: TextDirection) {
+    pub fn set_text_direction(&mut self, direction: TextDirection) -> &mut Self {
         self.native_mut().fTextDirection = direction;
+        self
     }
 
     pub fn text_align(&self) -> TextAlign {
         self.native().fTextAlign
     }
 
-    pub fn set_text_align(&mut self, align: TextAlign) {
-        self.native_mut().fTextAlign = align
+    pub fn set_text_align(&mut self, align: TextAlign) -> &mut Self {
+        self.native_mut().fTextAlign = align;
+        self
     }
 
     pub fn max_lines(&self) -> Option<usize> {
@@ -168,24 +179,27 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         }
     }
 
-    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) {
-        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value())
+    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) -> &mut Self {
+        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value());
+        self
     }
 
     pub fn ellipsis(&self) -> &str {
         self.native().fEllipsis.as_str()
     }
 
-    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) {
-        self.native_mut().fEllipsis.set_str(ellipsis)
+    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) -> &mut Self {
+        self.native_mut().fEllipsis.set_str(ellipsis);
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn unlimited_lines(&self) -> bool {
@@ -204,7 +218,8 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         self.native().fHintingIsOn
     }
 
-    pub fn turn_hinting_off(&mut self) {
-        self.native_mut().fHintingIsOn = false
+    pub fn turn_hinting_off(&mut self) -> &mut Self {
+        self.native_mut().fHintingIsOn = false;
+        self
     }
 }

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -1,0 +1,210 @@
+use super::{FontFamilies, TextAlign, TextDirection, TextStyle};
+use crate::interop::{AsStr, FromStrs, SetStr};
+use crate::prelude::*;
+use crate::{interop, scalar, FontStyle};
+use skia_bindings as sb;
+use std::slice;
+
+pub type StrutStyle = Handle<sb::skia_textlayout_StrutStyle>;
+
+impl NativeDrop for sb::skia_textlayout_StrutStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_StrutStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_StrutStyle {
+    fn clone(&self) -> Self {
+        construct(|ss| unsafe { sb::C_StrutStyle_CopyConstruct(ss, self) })
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_StrutStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_StrutStyle> {
+    pub fn new() -> Self {
+        StrutStyle::from_native(unsafe { sb::skia_textlayout_StrutStyle::new() })
+    }
+
+    pub fn font_families(&self) -> FontFamilies {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_StrutStyle_getFontFamilies(self.native(), &mut count);
+            FontFamilies(slice::from_raw_parts(ptr, count))
+        }
+    }
+
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
+        let families = interop::Strings::from_strs(families);
+        let families = families.native();
+        unsafe {
+            sb::C_StrutStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len());
+        }
+    }
+
+    pub fn font_style(&self) -> FontStyle {
+        FontStyle::from_native(self.native().fFontStyle)
+    }
+
+    pub fn set_font_style(&mut self, font_style: FontStyle) {
+        self.native_mut().fFontStyle = font_style.into_native()
+    }
+
+    pub fn font_size(&self) -> scalar {
+        self.native().fFontSize
+    }
+
+    pub fn set_font_size(&mut self, font_size: scalar) {
+        self.native_mut().fFontSize = font_size;
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_leading(&mut self, leading: scalar) {
+        self.native_mut().fLeading = leading;
+    }
+
+    pub fn leading(&self) -> scalar {
+        self.native().fLeading
+    }
+
+    pub fn strut_enabled(&self) -> bool {
+        self.native().fStrutEnabled
+    }
+
+    pub fn set_strut_enabled(&mut self, strut_enabled: bool) {
+        self.native_mut().fStrutEnabled = strut_enabled;
+    }
+
+    pub fn force_strut_height(&self) -> bool {
+        self.native().fForceStrutHeight
+    }
+
+    pub fn set_force_strut_height(&mut self, force_strut_height: bool) {
+        self.native_mut().fForceStrutHeight = force_strut_height;
+    }
+}
+
+pub type ParagraphStyle = Handle<sb::skia_textlayout_ParagraphStyle>;
+
+impl NativeDrop for sb::skia_textlayout_ParagraphStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_ParagraphStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_ParagraphStyle {
+    fn clone(&self) -> Self {
+        construct(|ps| unsafe { sb::C_ParagraphStyle_CopyConstruct(ps, self) })
+    }
+}
+
+impl NativePartialEq for sb::skia_textlayout_ParagraphStyle {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_ParagraphStyle_Equals(self, rhs) }
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_ParagraphStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_ParagraphStyle> {
+    pub fn new() -> Self {
+        Self::from_native(unsafe { sb::skia_textlayout_ParagraphStyle::new() })
+    }
+
+    pub fn strut_style(&self) -> &StrutStyle {
+        StrutStyle::from_native_ref(&self.native().fStrutStyle)
+    }
+
+    pub fn set_strut_style(&mut self, strut_style: StrutStyle) {
+        self.native_mut().fStrutStyle.replace_with(strut_style);
+    }
+
+    pub fn text_style(&self) -> &TextStyle {
+        TextStyle::from_native_ref(&self.native().fDefaultTextStyle)
+    }
+
+    pub fn set_text_style(&mut self, text_style: &TextStyle) {
+        // TODO: implement the assignment operator in C.
+        self.native_mut()
+            .fDefaultTextStyle
+            .replace_with(text_style.clone());
+    }
+
+    pub fn text_direction(&self) -> TextDirection {
+        self.native().fTextDirection
+    }
+
+    pub fn set_text_direction(&mut self, direction: TextDirection) {
+        self.native_mut().fTextDirection = direction;
+    }
+
+    pub fn text_align(&self) -> TextAlign {
+        self.native().fTextAlign
+    }
+
+    pub fn set_text_align(&mut self, align: TextAlign) {
+        self.native_mut().fTextAlign = align
+    }
+
+    pub fn max_lines(&self) -> Option<usize> {
+        match self.native().fLinesLimit {
+            std::usize::MAX => None,
+            lines => Some(lines),
+        }
+    }
+
+    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) {
+        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value())
+    }
+
+    pub fn ellipsis(&self) -> &str {
+        self.native().fEllipsis.as_str()
+    }
+
+    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) {
+        self.native_mut().fEllipsis.set_str(ellipsis)
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn unlimited_lines(&self) -> bool {
+        self.max_lines().is_none()
+    }
+
+    pub fn ellipsized(&self) -> bool {
+        !self.native().fEllipsis.as_str().is_empty()
+    }
+
+    pub fn effective_align(&self) -> TextAlign {
+        unsafe { self.native().effective_align() }
+    }
+
+    pub fn hinting_is_on(&self) -> bool {
+        self.native().fHintingIsOn
+    }
+
+    pub fn turn_hinting_off(&mut self) {
+        self.native_mut().fHintingIsOn = false
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -84,20 +84,20 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
     }
 
     pub fn strut_enabled(&self) -> bool {
-        self.native().fStrutEnabled
+        self.native().fEnabled
     }
 
-    pub fn set_strut_enabled(&mut self, strut_enabled: bool) -> &mut Self {
-        self.native_mut().fStrutEnabled = strut_enabled;
+    pub fn set_strut_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.native_mut().fEnabled = enabled;
         self
     }
 
     pub fn force_strut_height(&self) -> bool {
-        self.native().fForceStrutHeight
+        self.native().fForceHeight
     }
 
-    pub fn set_force_strut_height(&mut self, force_strut_height: bool) -> &mut Self {
-        self.native_mut().fForceStrutHeight = force_strut_height;
+    pub fn set_force_strut_height(&mut self, force_height: bool) -> &mut Self {
+        self.native_mut().fForceHeight = force_height;
         self
     }
 }

--- a/skia-safe/src/modules/paragraph/text_shadow.rs
+++ b/skia-safe/src/modules/paragraph/text_shadow.rs
@@ -1,0 +1,45 @@
+use crate::prelude::*;
+use crate::{Color, Point};
+use skia_bindings as sb;
+
+#[derive(Copy, Clone, Debug)]
+pub struct TextShadow {
+    pub color: Color,
+    pub offset: Point,
+    pub blur_radius: f64,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_TextShadow> for TextShadow {}
+
+#[test]
+fn text_shadow_layout() {
+    TextShadow::test_layout()
+}
+
+impl Default for TextShadow {
+    fn default() -> Self {
+        TextShadow::from_native(unsafe { sb::skia_textlayout_TextShadow::new() })
+    }
+}
+
+impl PartialEq for TextShadow {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { sb::C_TextShadow_Equals(self.native(), other.native()) }
+    }
+}
+
+impl TextShadow {
+    pub fn new(color: impl Into<Color>, offset: impl Into<Point>, blur_radius: f64) -> Self {
+        TextShadow::from_native(unsafe {
+            sb::skia_textlayout_TextShadow::new1(
+                color.into().into_native(),
+                offset.into().into_native(),
+                blur_radius,
+            )
+        })
+    }
+
+    pub fn has_shadow(&self) -> bool {
+        unsafe { self.native().hasShadow() }
+    }
+}

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -88,8 +88,9 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         Color::from_native(self.native().fColor)
     }
 
-    pub fn set_color(&mut self, color: impl Into<Color>) {
-        self.native_mut().fColor = color.into().into_native()
+    pub fn set_color(&mut self, color: impl Into<Color>) -> &mut Self {
+        self.native_mut().fColor = color.into().into_native();
+        self
     }
 
     pub fn foreground(&self) -> Option<&Paint> {
@@ -98,12 +99,13 @@ impl Handle<sb::skia_textlayout_TextStyle> {
             .if_true_some(Paint::from_native_ref(&self.native().fForeground))
     }
 
-    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) {
+    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         let n = self.native_mut();
         n.fHasForeground = paint
             .into()
             .map(|paint| n.fForeground.replace_with(paint))
             .is_some();
+        self
     }
 
     pub fn background(&self) -> Option<&Paint> {
@@ -112,12 +114,13 @@ impl Handle<sb::skia_textlayout_TextStyle> {
             .if_true_some(Paint::from_native_ref(&self.native().fBackground))
     }
 
-    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) {
+    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         let n = self.native_mut();
         n.fHasBackground = paint
             .into()
             .map(|paint| n.fBackground.replace_with(paint))
             .is_some();
+        self
     }
 
     pub fn decoration(&self) -> &Decoration {
@@ -132,8 +135,9 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         FontStyle::from_native(self.native().fFontStyle)
     }
 
-    pub fn set_font_style(&mut self, font_style: FontStyle) {
-        self.native_mut().fFontStyle = font_style.into_native()
+    pub fn set_font_style(&mut self, font_style: FontStyle) -> &mut Self {
+        self.native_mut().fFontStyle = font_style.into_native();
+        self
     }
 
     pub fn shadows(&self) -> &[TextShadow] {
@@ -145,12 +149,14 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         }
     }
 
-    pub fn add_shadow(&mut self, shadow: TextShadow) {
+    pub fn add_shadow(&mut self, shadow: TextShadow) -> &mut Self {
         unsafe { sb::C_TextStyle_addShadow(self.native_mut(), shadow.native()) }
+        self
     }
 
-    pub fn reset_shadows(&mut self) {
+    pub fn reset_shadows(&mut self) -> &mut Self {
         unsafe { sb::C_TextStyle_resetShadows(self.native_mut()) }
+        self
     }
 
     pub fn font_families(&self) -> FontFamilies {
@@ -161,32 +167,36 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         }
     }
 
-    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
-        let families = interop::Strings::from_strs(families);
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) -> &mut Self {
+        let families: Vec<interop::String> = FromStrs::from_strs(families);
         let families = families.native();
         unsafe {
             sb::C_TextStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len())
         }
+        self
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) {
+    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) -> &mut Self {
         self.native_mut().fLetterSpacing = letter_spacing;
+        self
     }
 
     pub fn letter_spacing(&self) -> scalar {
         self.native().fLetterSpacing
     }
 
-    pub fn set_word_spacing(&mut self, word_spacing: scalar) {
+    pub fn set_word_spacing(&mut self, word_spacing: scalar) -> &mut Self {
         self.native_mut().fWordSpacing = word_spacing;
+        self
     }
 
     pub fn word_spacing(&self) -> scalar {
@@ -197,26 +207,29 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         Typeface::from_unshared_ptr(self.native().fTypeface.fPtr)
     }
 
-    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) {
+    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) -> &mut Self {
         unsafe {
             sb::C_TextStyle_setTypeface(self.native_mut(), typeface.into().into_ptr_or_null())
         }
+        self
     }
 
     pub fn locale(&self) -> &str {
         self.native().fLocale.as_str()
     }
 
-    pub fn set_locale(&mut self, locale: impl AsRef<str>) {
-        self.native_mut().fLocale.set_str(locale)
+    pub fn set_locale(&mut self, locale: impl AsRef<str>) -> &mut Self {
+        self.native_mut().fLocale.set_str(locale);
+        self
     }
 
     pub fn text_baseline(&self) -> TextBaseline {
         self.native().fTextBaseline
     }
 
-    pub fn set_text_baseline(&mut self, baseline: TextBaseline) {
-        self.native_mut().fTextBaseline = baseline
+    pub fn set_text_baseline(&mut self, baseline: TextBaseline) -> &mut Self {
+        self.native_mut().fTextBaseline = baseline;
+        self
     }
 
     pub fn font_metrics(&self) -> FontMetrics {

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -30,7 +30,7 @@ pub use sb::skia_textlayout_TextDecorationStyle as TextDecorationStyle;
 
 pub use sb::skia_textlayout_StyleType as StyleType;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Default, Debug)]
 pub struct Decoration {
     pub ty: TextDecoration,
     pub color: Color,

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -1,0 +1,227 @@
+use super::{FontFamilies, TextBaseline, TextShadow};
+use crate::interop::{AsStr, FromStrs, SetStr};
+use crate::prelude::*;
+use crate::{interop, scalar, Color, FontMetrics, FontStyle, Paint, Typeface};
+use skia_bindings as sb;
+use std::slice;
+
+bitflags! {
+    pub struct TextDecoration: u32 {
+        const NO_DECORATION = sb::skia_textlayout_TextDecoration::kNoDecoration as _;
+        const UNDERLINE = sb::skia_textlayout_TextDecoration::kUnderline as _;
+        const OVERLINE = sb::skia_textlayout_TextDecoration::kOverline as _;
+        const LINE_THROUGH = sb::skia_textlayout_TextDecoration::kOverline as _;
+    }
+}
+
+pub const ALL_TEXT_DECORATIONS: TextDecoration = TextDecoration::ALL;
+
+impl Default for TextDecoration {
+    fn default() -> Self {
+        TextDecoration::NO_DECORATION
+    }
+}
+
+impl TextDecoration {
+    pub const ALL: TextDecoration = TextDecoration::all();
+}
+
+pub use sb::skia_textlayout_TextDecorationStyle as TextDecorationStyle;
+
+pub use sb::skia_textlayout_StyleType as StyleType;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Decoration {
+    pub ty: TextDecoration,
+    pub color: Color,
+    pub style: TextDecorationStyle,
+    pub thickness_multiplier: scalar,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_Decoration> for Decoration {}
+
+#[test]
+fn decoration_layout() {
+    Decoration::test_layout();
+}
+
+pub type TextStyle = Handle<sb::skia_textlayout_TextStyle>;
+
+impl NativeDrop for sb::skia_textlayout_TextStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_TextStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_TextStyle {
+    fn clone(&self) -> Self {
+        construct(|ts| unsafe { sb::C_TextStyle_CopyConstruct(ts, self) })
+    }
+}
+
+impl NativePartialEq for sb::skia_textlayout_TextStyle {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { self.equals(rhs) }
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_TextStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_TextStyle> {
+    pub fn new() -> Self {
+        TextStyle::from_native(unsafe { sb::skia_textlayout_TextStyle::new() })
+    }
+
+    pub fn equals(&self, other: &TextStyle) -> bool {
+        *self == *other
+    }
+
+    pub fn match_one_attribute(&self, style_type: StyleType, other: &TextStyle) -> bool {
+        unsafe { self.native().matchOneAttribute(style_type, other.native()) }
+    }
+
+    pub fn color(&self) -> Color {
+        Color::from_native(self.native().fColor)
+    }
+
+    pub fn set_color(&mut self, color: impl Into<Color>) {
+        self.native_mut().fColor = color.into().into_native()
+    }
+
+    pub fn foreground(&self) -> Option<&Paint> {
+        self.native()
+            .fHasForeground
+            .if_true_some(Paint::from_native_ref(&self.native().fForeground))
+    }
+
+    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) {
+        let n = self.native_mut();
+        n.fHasForeground = paint
+            .into()
+            .map(|paint| n.fForeground.replace_with(paint))
+            .is_some();
+    }
+
+    pub fn background(&self) -> Option<&Paint> {
+        self.native()
+            .fHasBackground
+            .if_true_some(Paint::from_native_ref(&self.native().fBackground))
+    }
+
+    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) {
+        let n = self.native_mut();
+        n.fHasBackground = paint
+            .into()
+            .map(|paint| n.fBackground.replace_with(paint))
+            .is_some();
+    }
+
+    pub fn decoration(&self) -> &Decoration {
+        Decoration::from_native_ref(&self.native().fDecoration)
+    }
+
+    pub fn decoration_mut(&mut self) -> &mut Decoration {
+        Decoration::from_native_ref_mut(&mut self.native_mut().fDecoration)
+    }
+
+    pub fn font_style(&self) -> FontStyle {
+        FontStyle::from_native(self.native().fFontStyle)
+    }
+
+    pub fn set_font_style(&mut self, font_style: FontStyle) {
+        self.native_mut().fFontStyle = font_style.into_native()
+    }
+
+    pub fn shadows(&self) -> &[TextShadow] {
+        unsafe {
+            let ts: &sb::TextShadows = transmute_ref(&self.native().fTextShadows);
+            let mut cnt = 0;
+            let ptr = TextShadow::from_native_ref(&*sb::C_TextShadows_ptr_count(ts, &mut cnt));
+            slice::from_raw_parts(ptr, cnt)
+        }
+    }
+
+    pub fn add_shadow(&mut self, shadow: TextShadow) {
+        unsafe { sb::C_TextStyle_addShadow(self.native_mut(), shadow.native()) }
+    }
+
+    pub fn reset_shadows(&mut self) {
+        unsafe { sb::C_TextStyle_resetShadows(self.native_mut()) }
+    }
+
+    pub fn font_families(&self) -> FontFamilies {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_TextStyle_getFontFamilies(self.native(), &mut count);
+            FontFamilies(slice::from_raw_parts(ptr, count))
+        }
+    }
+
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
+        let families = interop::Strings::from_strs(families);
+        let families = families.native();
+        unsafe {
+            sb::C_TextStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len())
+        }
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) {
+        self.native_mut().fLetterSpacing = letter_spacing;
+    }
+
+    pub fn letter_spacing(&self) -> scalar {
+        self.native().fLetterSpacing
+    }
+
+    pub fn set_word_spacing(&mut self, word_spacing: scalar) {
+        self.native_mut().fWordSpacing = word_spacing;
+    }
+
+    pub fn word_spacing(&self) -> scalar {
+        self.native().fWordSpacing
+    }
+
+    pub fn typeface(&self) -> Option<Typeface> {
+        Typeface::from_unshared_ptr(self.native().fTypeface.fPtr)
+    }
+
+    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) {
+        unsafe {
+            sb::C_TextStyle_setTypeface(self.native_mut(), typeface.into().into_ptr_or_null())
+        }
+    }
+
+    pub fn locale(&self) -> &str {
+        self.native().fLocale.as_str()
+    }
+
+    pub fn set_locale(&mut self, locale: impl AsRef<str>) {
+        self.native_mut().fLocale.set_str(locale)
+    }
+
+    pub fn text_baseline(&self) -> TextBaseline {
+        self.native().fTextBaseline
+    }
+
+    pub fn set_text_baseline(&mut self, baseline: TextBaseline) {
+        self.native_mut().fTextBaseline = baseline
+    }
+
+    pub fn font_metrics(&self) -> FontMetrics {
+        let mut m = FontMetrics::default();
+        unsafe { sb::C_TextStyle_getFontMetrics(self.native(), m.native_mut()) }
+        m
+    }
+}

--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -38,8 +38,9 @@ impl RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
         self.native().fAlias.as_str()
     }
 
-    pub fn append_typeface(&mut self, typeface: Typeface) {
+    pub fn append_typeface(&mut self, typeface: Typeface) -> &mut Self {
         unsafe { sb::C_TypefaceFontStyleSet_appendTypeface(self.native_mut(), typeface.into_ptr()) }
+        self
     }
 }
 

--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -1,0 +1,126 @@
+use crate::interop::AsStr;
+use crate::prelude::*;
+use crate::{interop, FontMgr, FontStyleSet, Typeface};
+use skia_bindings as sb;
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+pub type TypefaceFontStyleSet = RCHandle<sb::skia_textlayout_TypefaceFontStyleSet>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_TypefaceFontStyleSet {
+    type Base = sb::SkRefCntBase;
+}
+
+impl Deref for RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    type Target = FontStyleSet;
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute_ref(self) }
+    }
+}
+
+impl DerefMut for RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { transmute_ref_mut(self) }
+    }
+}
+
+impl RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    pub fn new(family_name: impl AsRef<str>) -> Self {
+        let family = interop::String::from_str(family_name.as_ref());
+        Self::from_ptr(unsafe { sb::C_TypefaceFontStyleSet_new(family.native()) }).unwrap()
+    }
+
+    pub fn family_name(&self) -> &str {
+        self.native().fFamilyName.as_str()
+    }
+
+    pub fn alias(&self) -> &str {
+        self.native().fAlias.as_str()
+    }
+
+    pub fn append_typeface(&mut self, typeface: Typeface) {
+        unsafe { sb::C_TypefaceFontStyleSet_appendTypeface(self.native_mut(), typeface.into_ptr()) }
+    }
+}
+
+pub type TypefaceFontProvider = RCHandle<sb::skia_textlayout_TypefaceFontProvider>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_TypefaceFontProvider {
+    type Base = sb::SkRefCntBase;
+}
+
+impl Deref for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    type Target = FontMgr;
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute_ref(self) }
+    }
+}
+
+impl DerefMut for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { transmute_ref_mut(self) }
+    }
+}
+
+impl Default for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    pub fn new() -> Self {
+        Self::from_ptr(unsafe { sb::C_TypefaceFontProvider_new() }).unwrap()
+    }
+
+    pub fn register_typeface(
+        &mut self,
+        typeface: Typeface,
+        alias: Option<impl AsRef<str>>,
+    ) -> usize {
+        unsafe {
+            match alias {
+                Some(alias) => {
+                    let alias = interop::String::from_str(alias.as_ref());
+                    sb::C_TypefaceFontProvider_registerTypeface(
+                        self.native_mut(),
+                        typeface.into_ptr(),
+                        alias.native(),
+                    )
+                }
+                None => sb::C_TypefaceFontProvider_registerTypeface(
+                    self.native_mut(),
+                    typeface.into_ptr(),
+                    ptr::null(),
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypefaceFontStyleSet;
+    use crate::prelude::{NativeAccess, NativeRefCounted, NativeRefCountedBase};
+    use crate::Typeface;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn font_style_set_typeface_ref_counts() {
+        let mut style_set = TypefaceFontStyleSet::new("");
+        assert_eq!(style_set.native().ref_counted_base()._ref_cnt(), 1);
+
+        let tf = Typeface::default();
+        let base_cnt = tf.native().ref_counted_base()._ref_cnt();
+
+        let tfclone = tf.clone();
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt + 1);
+
+        style_set.append_typeface(tfclone);
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt + 1);
+
+        drop(style_set);
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt);
+        drop(tf);
+    }
+}

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -585,6 +585,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test_derive::serial]
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -21,7 +21,7 @@ impl NativeDrop for SkShaper {
 
 impl Default for RefHandle<SkShaper> {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -30,16 +30,26 @@ impl RefHandle<SkShaper> {
         Self::from_ptr(unsafe { sb::C_SkShaper_MakePrimitive() }).unwrap()
     }
 
-    pub fn new_shaper_driven_wrapper() -> Option<Self> {
-        Self::from_ptr(unsafe { sb::C_SkShaper_MakeShaperDrivenWrapper() })
+    pub fn new_shaper_driven_wrapper(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShaperDrivenWrapper(font_mgr.into().into_ptr_or_null())
+        })
     }
 
-    pub fn new_shape_then_wrap() -> Option<Self> {
-        Self::from_ptr(unsafe { sb::C_SkShaper_MakeShapeThenWrap() })
+    pub fn new_shape_then_wrap(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShapeThenWrap(font_mgr.into().into_ptr_or_null())
+        })
     }
 
-    pub fn new() -> Self {
-        Self::from_ptr(unsafe { sb::C_SkShaper_Make() }).unwrap()
+    pub fn new_shape_dont_wrap_or_reorder(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShapeDontWrapOrReorder(font_mgr.into().into_ptr_or_null())
+        })
+    }
+
+    pub fn new(font_mgr: impl Into<Option<FontMgr>>) -> Self {
+        Self::from_ptr(unsafe { sb::C_SkShaper_Make(font_mgr.into().into_ptr_or_null()) }).unwrap()
     }
 }
 
@@ -578,7 +588,7 @@ mod tests {
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 
-        let shaper = Shaper::new();
+        let shaper = Shaper::new(None);
         shaper.shape(
             "العربية",
             &Font::default(),

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -494,9 +494,7 @@ impl<N: NativeRefCounted> NativeAccess<N> for RCHandle<N> {
 
 impl<N: NativeRefCounted> Clone for RCHandle<N> {
     fn clone(&self) -> Self {
-        // yes, we _do_ support shared mutability when
-        // a ref-counted handle is cloned, so beware of spooky action at
-        // a distance.
+        // Support shared mutability when a ref-counted handle is cloned.
         let ptr = self.0;
         unsafe { (&*ptr)._ref() };
         Self(ptr)

--- a/skia-safe/src/svg/canvas.rs
+++ b/skia-safe/src/svg/canvas.rs
@@ -38,6 +38,7 @@ bitflags! {
     #[derive(Default)]
     pub struct Flags : u32 {
         const CONVERT_TEXT_TO_PATHS = sb::SkSVGCanvas_kConvertTextToPaths_Flag as _;
+        const NO_PRETTY_XML = sb::SkSVGCanvas_kNoPrettyXML_Flag as _;
     }
 }
 
@@ -81,8 +82,7 @@ fn test_svg() {
     let data = canvas.end();
     let contents = String::from_utf8_lossy(data.as_bytes());
     dbg!(&contents);
-    assert!(contents
-        .contains(r#"<ellipse fill="rgb(0,0,0)" stroke="none" cx="10" cy="10" rx="10" ry="10"/>"#));
+    assert!(contents.contains(r#"<ellipse cx="10" cy="10" rx="10" ry="10"/>"#));
     assert!(contents.contains(r#"</svg>"#));
 }
 


### PR DESCRIPTION
This PR adds the C bindings and Rust wrappers for the skparagraph module to the M78 branch.

This is a followup PR based on rust-skia#186 to see if an M78 base is better suited to wrap `modules/skparagraph`.

**Update:** Getting consistent heap corruptions when layouting a simple paragraph with M77, but not in M78, so development is continues here.

- [x] C bindings
- [x] Rust wrapper
- [x] Rename feature `paragraph` to `textlayout`?
- [x] return `-> &mut Self` for setters of *Style types
- [x] Support to build on all platforms
- [x] Update from m77 to m78.
- [x] Add example
- [ ] Update README