### PR TITLE
Remove depot tools

### DIFF
--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -34,6 +34,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -437,6 +440,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -29,6 +29,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -432,6 +435,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -835,6 +841,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -1238,6 +1247,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -1641,6 +1653,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -2044,6 +2059,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -2447,6 +2465,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -2850,6 +2871,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -3253,6 +3277,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -3656,6 +3683,9 @@ jobs:
 
     - name: Install Clippy
       run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
     - name: 'Install Rust target x86_64-apple-darwin'
       shell: bash
       run: |
@@ -4011,6 +4041,412 @@ jobs:
       if: false
       run: |
         cargo run --release --features "gl,svg,textlayout" --target x86_64-apple-ios "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-x86_64-apple-ios
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+  macos-release-release-gl-svg-textlayout-vulkan:
+    runs-on: macos-13
+    env:
+      SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1.4.0
+      with:
+        rust-version: stable
+
+    - name: Install Clippy
+      run: rustup component add clippy
+
+    - name: Install Ninja
+      run: brew install ninja
+    - name: 'Install Rust target x86_64-apple-darwin'
+      shell: bash
+      run: |
+        rustup target add x86_64-apple-darwin
+
+    - name: 'Build skia-safe for x86_64-apple-darwin with features gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=x86_64-apple-darwin
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=x86_64-apple-darwin26-clang
+          export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "gl,svg,textlayout,vulkan" --target x86_64-apple-darwin
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: true
+      run: |
+        cargo clippy --release --features "gl,svg,textlayout,vulkan" --all-targets --target x86_64-apple-darwin -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: true
+      run: |
+        cargo test --all --release --features "gl,svg,textlayout,vulkan" --all-targets --target x86_64-apple-darwin -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,svg,textlayout,vulkan" --target x86_64-apple-darwin "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-x86_64-apple-darwin
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target aarch64-apple-darwin'
+      shell: bash
+      run: |
+        rustup target add aarch64-apple-darwin
+
+    - name: 'Build skia-safe for aarch64-apple-darwin with features gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=aarch64-apple-darwin
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=aarch64-apple-darwin26-clang
+          export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-darwin
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-darwin -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-darwin -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-darwin "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-aarch64-apple-darwin
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target aarch64-apple-ios'
+      shell: bash
+      run: |
+        rustup target add aarch64-apple-ios
+
+    - name: 'Build skia-safe for aarch64-apple-ios with features gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=aarch64-apple-ios
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=aarch64-apple-ios26-clang
+          export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-ios
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-ios -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-ios -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-ios "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-aarch64-apple-ios
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target aarch64-apple-ios-sim'
+      shell: bash
+      run: |
+        rustup target add aarch64-apple-ios-sim
+
+    - name: 'Build skia-safe for aarch64-apple-ios-sim with features gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=aarch64-apple-ios-sim
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=aarch64-apple-ios-sim26-clang
+          export CXX_${TARGET}=aarch64-apple-ios-sim26-clang++
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-ios-sim
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-ios-sim -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,svg,textlayout,vulkan" --all-targets --target aarch64-apple-ios-sim -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,svg,textlayout,vulkan" --target aarch64-apple-ios-sim "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-aarch64-apple-ios-sim
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target x86_64-apple-ios'
+      shell: bash
+      run: |
+        rustup target add x86_64-apple-ios
+
+    - name: 'Build skia-safe for x86_64-apple-ios with features gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=x86_64-apple-ios
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=x86_64-apple-ios26-clang
+          export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "gl,svg,textlayout,vulkan" --target x86_64-apple-ios
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,svg,textlayout,vulkan" --all-targets --target x86_64-apple-ios -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,svg,textlayout,vulkan" --all-targets --target x86_64-apple-ios -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,svg,textlayout,vulkan" --target x86_64-apple-ios "${{ env.SKIA_STAGING_PATH }}/skia-org" 
 
     - name: 'Upload skia-org example images'
       if: false

--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -170,6 +170,9 @@ jobs:
     - name: Upgrade LLVM
       run: choco upgrade llvm
 
+    - name: Install Ninja
+      run: choco install ninja
+
     - name: 'Install Rust target i686-pc-windows-msvc'
       shell: bash
       run: |

--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -110,6 +110,9 @@ jobs:
     - name: Upgrade LLVM
       run: choco upgrade llvm
 
+    - name: Install Ninja
+      run: choco install ninja
+
     - name: 'Build with RUSTFLAGS=-Clink-dead-code (#318)'
       run: |
         # See https://github.com/rust-lang/rust/issues/90056 why we have to provide a target.
@@ -136,6 +139,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
 
     - name: 'Build with RUSTFLAGS=-Clink-dead-code (#318)'
       run: |

--- a/.github/workflows/windows-qa.yaml
+++ b/.github/workflows/windows-qa.yaml
@@ -42,6 +42,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -145,6 +148,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |

--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -37,6 +37,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -140,6 +143,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -243,6 +249,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -346,6 +355,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -449,6 +461,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -552,6 +567,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -655,6 +673,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -758,6 +779,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -861,6 +885,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -964,6 +991,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -1067,6 +1097,9 @@ jobs:
 
     - name: Upgrade LLVM
       run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
     - name: 'Install Rust target x86_64-pc-windows-msvc'
       shell: bash
       run: |
@@ -1114,6 +1147,112 @@ jobs:
       if: false
       run: |
         cargo run --release --features "gl,svg,textlayout" --target x86_64-pc-windows-msvc "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: skia-org-images-x86_64-pc-windows-msvc
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+
+    - name: 'Compress binaries'
+      if: true
+      uses: a7ul/tar-action@v1.1.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@v1.11.1-rs
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+  windows-release-release-d3d-gl-svg-textlayout-vulkan:
+    runs-on: windows-2022
+    # Containers are not supported on Windows.
+    # container: ghcr.io/pragmatrix/rust-skia-windows:latest
+    env: 
+      SKIA_DEBUG: 0
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1.4.0
+      with:
+        rust-version: stable
+
+    - name: Install Clippy
+      run: rustup component add clippy
+      shell: bash
+
+    - name: Python Version
+      run: python --version
+
+    - name: Upgrade LLVM
+      run: choco upgrade llvm
+
+    - name: Install Ninja
+      run: choco install ninja
+    - name: 'Install Rust target x86_64-pc-windows-msvc'
+      shell: bash
+      run: |
+        rustup target add x86_64-pc-windows-msvc
+
+    - name: 'Build skia-safe for x86_64-pc-windows-msvc with features d3d,gl,svg,textlayout,vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=x86_64-pc-windows-msvc
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
+          export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --release --features "d3d,gl,svg,textlayout,vulkan" --target x86_64-pc-windows-msvc
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+
+    - name: 'Run Clippy'
+      shell: bash
+      if: true
+      run: |
+        cargo clippy --release --features "d3d,gl,svg,textlayout,vulkan" --all-targets --target x86_64-pc-windows-msvc -- -D warnings
+
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: true
+      run: |
+        cargo test --all --release --features "d3d,gl,svg,textlayout,vulkan" --all-targets --target x86_64-pc-windows-msvc -- --nocapture
+
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "d3d,gl,svg,textlayout,vulkan" --target x86_64-pc-windows-msvc "${{ env.SKIA_STAGING_PATH }}/skia-org" 
 
     - name: 'Upload skia-org example images'
       if: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "skia"]
 	path = skia-bindings/skia
 	url = https://github.com/rust-skia/skia.git
-[submodule "skia-bindings/depot_tools"]
-	path = skia-bindings/depot_tools
-	url = https://github.com/rust-skia/depot_tools.git

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The supported wrappers, Skia codecs, and additional Skia features are documented
 
 If the target platform or feature configuration is not available as a prebuilt binary, skia-bindings' `build.rs` will try to build Skia and generate the Rust bindings.
 
-To prepare for that, **LLVM** and **Python 3** are needed:
+For building Skia from source, **LLVM**, **Python 3**, and **Ninja** are required:
 
 **LLVM**
 
@@ -67,6 +67,10 @@ We recommend the version that comes preinstalled with your platform, or, if not 
 **Python 3**
 
 The build script probes for `python --version` and `python3 --version` and uses the first one that looks like a version 3 executable for building Skia.
+
+**Ninja**
+
+The build system for Skia. `ninja` is available as a binary package on all major platforms. Install `ninja` or `ninja-build` and make sure it is available `PATH` with `ninja --version`.
 
 ### On macOS
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ The build system for Skia. `ninja` is available as a binary package on all major
 
   or download and install the [Command Line Tools for Xcode](https://developer.apple.com/download/more/).
 
-- **macOS Mojave only**: install the SDK headers:
-
-  ```bash
-  sudo open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
-  ```
-
-  If not installed, the Skia build _may_ fail to build `SkJpegUtility.cpp` and the binding generation _will_ fail with `'TargetConditionals.h' file not found` . Also note that the Command Line Tools _and_ SDK headers _should_ be reinstalled after an update of XCode.
-
 - As an alternative to Apple's XCode LLVM, install LLVM via `brew install llvm` or `brew install llvm` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
 
   If the environment variables are not set, [bindgen](https://github.com/rust-lang/rust-bindgen) will most likely use the wrong `libclang.dylib` and cause confusing compilation errors (see #228).
@@ -119,38 +111,12 @@ The build system for Skia. `ninja` is available as a binary package on all major
 
 ### On Linux
 
-#### Ubuntu 16+
+#### Ubuntu 20+
 
 - LLVM/Clang should be available already, if not, [install the latest version](http://releases.llvm.org/download.html).
 - If OpenGL libraries are missing, install the drivers for you graphics card, or a mesa package like `libgl1-mesa-dev`.
 - For **X11**, build with feature `x11`.
 - For **Wayland**, install `libwayland-dev` and build with the `wayland` feature.
-
-#### CentOS 7
-
-- Install the following packages:
-
-  ```bash
-  sudo yum install gcc openssl-devel libX11-devel python3 fontconfig-devel mesa-libGL-devel
-  ```
-
-- [Install and enable the LLVM toolset 7](https://www.softwarecollections.org/en/scls/rhscl/llvm-toolset-7.0/)
-
-- [Install and enable the Developer Toolset 8](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/)
-
-#### CentOS 8
-
-- Install the following packages:
-
-  ```bash
-  sudo yum install gcc openssl-devel libX11-devel python3 clang fontconfig-devel mesa-libGL-devel
-  ```
-
-- Set `/usr/bin/python3` as the default `python` command:
-
-  ```bash
-  sudo alternatives --set python /usr/bin/python3
-  ```
 
 ### For Android
 

--- a/mk-workflows/src/templates/macos-job.yaml
+++ b/mk-workflows/src/templates/macos-job.yaml
@@ -15,3 +15,7 @@ steps:
 
 - name: Install Clippy
   run: rustup component add clippy
+
+- name: Install Ninja
+  run: brew install ninja
+

--- a/mk-workflows/src/templates/windows-job.yaml
+++ b/mk-workflows/src/templates/windows-job.yaml
@@ -23,3 +23,6 @@ steps:
 
 - name: Upgrade LLVM
   run: choco upgrade llvm
+
+- name: Install Ninja
+  run: choco install ninja

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -27,11 +27,10 @@ include = [
 [lib]
 doctest = false
 
-# Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
+# Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
 skia = "m130-0.78.1"
-depot_tools = "cc924d1"
 
 [features]
 default = ["binary-cache", "embed-icudtl"]
@@ -68,8 +67,6 @@ bindgen = { version = "0.70.1" }
 regex = "1.4.5"
 heck = "0.5.0"
 
-# For downloading and extracting prebuilt binaries and skia / depot_tools archives:
-# ureq = { version = "2.8.0", optional = true }
 flate2 = { version = "1.0.7", optional = true }
 tar = { version = "0.4.26", optional = true }
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
 skia = "m130-0.78.1"
-depot_tools = "73a2624"
+depot_tools = "cc924d1"
 
 [features]
 default = ["binary-cache", "embed-icudtl"]

--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -9,9 +9,9 @@ use std::{
     process::{Command, Stdio},
 };
 
-/// Resolve the `skia/` and `depot_tools/` subdirectory contents, either by checking out the
-/// submodules, or when `build.rs` was invoked outside of the git repository by downloading and
-/// unpacking them from GitHub.
+/// Resolve the `skia/` subdirectory contents, either by checking out the submodules, or when
+/// `build.rs` was invoked outside of the git repository by downloading and unpacking them from
+/// GitHub.
 pub fn resolve_dependencies() {
     if cargo::is_crate() {
         // In a crate.
@@ -37,7 +37,7 @@ pub fn resolve_dependencies() {
     }
 }
 
-/// Downloads the `skia` and `depot_tools` from their repositories.
+/// Downloads the `skia` from its repository.
 ///
 /// The hashes are taken from the `Cargo.toml` section `[package.metadata]`.
 fn download_dependencies() {
@@ -117,34 +117,17 @@ struct Dependency {
     pub path_filter: fn(&Path) -> bool,
 }
 
-const DEPENDENCIES: [Dependency; 2] = [
-    Dependency {
-        repo: "skia",
-        url: "https://codeload.github.com/rust-skia/skia/tar.gz",
-        path_filter: filter_skia,
-    },
-    Dependency {
-        repo: "depot_tools",
-        url: "https://codeload.github.com/rust-skia/depot_tools/tar.gz",
-        path_filter: filter_depot_tools,
-    },
-];
+const DEPENDENCIES: &[Dependency] = &[Dependency {
+    repo: "skia",
+    url: "https://codeload.github.com/rust-skia/skia/tar.gz",
+    path_filter: filter_skia,
+}];
 
 // `infra/` contains very long filenames which may hit the max path restriction on Windows.
 // <https://github.com/rust-skia/rust-skia/issues/169>
 fn filter_skia(p: &Path) -> bool {
     !matches!(p.components().next(),
             Some(Component::Normal(name)) if name == OsStr::new("infra"))
-}
-
-// Need only `ninja` and what `ninja.py` refers to from `depot_tools/`.
-// <https://github.com/rust-skia/rust-skia/pull/165>
-fn filter_depot_tools(p: &Path) -> bool {
-    if p.components().count() != 1 {
-        return false;
-    }
-    let str = p.to_str().unwrap();
-    str.starts_with("ninja") || str.ends_with(".py")
 }
 
 impl binaries_config::BinariesConfiguration {

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -267,13 +267,7 @@ pub fn build(
 ) {
     let python = &prerequisites::locate_python3_cmd();
     println!("Python 3 found: {python:?}");
-
-    let ninja = ninja_command.unwrap_or_else(|| {
-        env::current_dir()
-            .unwrap()
-            .join("depot_tools")
-            .join(ninja::depot_tools_script_name())
-    });
+    let ninja = ninja_command.unwrap_or_else(ninja::exe_name);
 
     if !offline {
         println!("Synchronizing Skia dependencies");
@@ -357,7 +351,7 @@ pub fn build_skia(config: &binaries_config::BinariesConfiguration, ninja_command
 
     assert!(
         ninja_status
-            .expect("failed to run `ninja`, does the directory depot_tools/ exist?")
+            .expect("failed to run `ninja`, does it exist in PATH?")
             .success(),
         "`ninja` returned an error, please check the output for details."
     );
@@ -405,9 +399,9 @@ mod ninja {
 
     use super::cargo;
 
-    pub fn depot_tools_script_name() -> PathBuf {
+    pub fn exe_name() -> PathBuf {
         if cargo::host().is_windows() {
-            "ninja.bat"
+            "ninja.exe"
         } else {
             "ninja"
         }

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -272,7 +272,7 @@ pub fn build(
         env::current_dir()
             .unwrap()
             .join("depot_tools")
-            .join(ninja::default_exe_name())
+            .join(ninja::depot_tools_script_name())
     });
 
     if !offline {
@@ -403,7 +403,14 @@ mod prerequisites {
 mod ninja {
     use std::path::PathBuf;
 
-    pub fn default_exe_name() -> PathBuf {
-        if cfg!(windows) { "ninja.exe" } else { "ninja" }.into()
+    use super::cargo;
+
+    pub fn depot_tools_script_name() -> PathBuf {
+        if cargo::host().is_windows() {
+            "ninja.bat"
+        } else {
+            "ninja"
+        }
+        .into()
     }
 }


### PR DESCRIPTION
As we are only using ninja from depot-tools, I suspect that depot_tools can be removed completely. This PR attempts to see if that works.